### PR TITLE
Update reply_captcha.xml

### DIFF
--- a/Clover/app/src/main/res/layout/reply_captcha.xml
+++ b/Clover/app/src/main/res/layout/reply_captcha.xml
@@ -41,6 +41,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/reply_captcha"
-        android:inputType="textNoSuggestions"/>
+        android:inputType="textNoSuggestions|textVisiblePassword"/>
 
 </LinearLayout>


### PR DESCRIPTION
Depending on the keyboard and device, Captcha text suggestions are still appearing. Changing the input type to textVisiblePassword as suggested by http://stackoverflow.com/questions/10870111/edit-text-without-autocorrect should solve this.
