### PR TITLE
Display message instead of ProgressBar when there is no thread specified

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/fragment/ThreadFragment.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/fragment/ThreadFragment.java
@@ -171,6 +171,10 @@ public class ThreadFragment extends Fragment implements ThreadManager.ThreadMana
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         container = new LoadView(inflater.getContext());
+        if (loadable == null) {
+            container.setView(getCenteredMessageView(R.string.thread_not_specified));
+        }
+
         return container;
     }
 
@@ -423,6 +427,16 @@ public class ThreadFragment extends Fragment implements ThreadManager.ThreadMana
         }
 
         return errorMessage;
+    }
+
+    private View getCenteredMessageView(int stringResourceId) {
+        LinearLayout layout = new LinearLayout(baseActivity);
+        layout.setGravity(Gravity.CENTER);
+        TextView messageView = new TextView(baseActivity);
+        messageView.setText(getString(stringResourceId));
+        layout.addView(messageView);
+
+        return layout;
     }
 
     private static class SkipLogic {

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="thread_load_failed_parsing">Server inaccessible</string>
     <string name="thread_load_failed_server">404 not found</string>
     <string name="thread_load_end_of_line">No more posts</string>
+    <string name="thread_not_specified">Select a thread</string>
     <string name="thread_refresh_bar_inactive">Tap to refresh</string>
     <string name="thread_refresh_now">Loading</string>
     <string name="thread_refresh_countdown">Loading in %1$d</string>


### PR DESCRIPTION
When cold booting the application, the right pane shows a ProgressBar. This changes the endless ProgressBar in the right pane to a (generic) TextView that shows "Select a thread".

Feedback on the actual message would be appreciated. Is "Select a thread" a good choice?
