### PR TITLE
Remove circular ProgressBar from ActionBar

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/activity/ImageViewActivity.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/activity/ImageViewActivity.java
@@ -26,7 +26,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.SubMenu;
 import android.view.View;
-import android.view.Window;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 
@@ -82,7 +81,6 @@ public class ImageViewActivity extends Activity implements ViewPager.OnPageChang
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         ActionBar actionBar = getActionBar();
         actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_TITLE | ActionBar.DISPLAY_HOME_AS_UP);
 

--- a/Clover/app/src/main/java/org/floens/chan/ui/fragment/ImageViewFragment.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/fragment/ImageViewFragment.java
@@ -53,7 +53,6 @@ public class ImageViewFragment extends Fragment implements ThumbnailImageViewCal
     private ThumbnailImageView imageView;
 
     private Post post;
-    private boolean showProgressBar = true;
     private boolean isVideo = false;
     private boolean videoVisible = false;
     private boolean videoSetIconToPause = false;
@@ -174,8 +173,6 @@ public class ImageViewFragment extends Fragment implements ThumbnailImageViewCal
     }
 
     public void onSelected(ImageViewAdapter adapter, int position) {
-        activity.setProgressBarIndeterminateVisibility(showProgressBar);
-
         String filename = post.filename + "." + post.ext;
         activity.getActionBar().setTitle(filename);
 
@@ -305,7 +302,6 @@ public class ImageViewFragment extends Fragment implements ThumbnailImageViewCal
     }
 
     public void showProgressBar(boolean e) {
-        showProgressBar = e;
         activity.updateActionBarIfSelected(this);
     }
 


### PR DESCRIPTION
This removes the circular ProgressBar from the ActionBar when loading
images/gifs/webms. There already is a custom horizontal ProgressBar
running that's determinate. Having two ProgressBars, one in the
ActionBar, one below the ActionBar, is kind of overkill.

The `boolean showProgressBar` variable remained unused after these changes, so it's removed from code as well.

Any feedback on this is appreciated.