### PR TITLE
Wrap pinned ListView around a parent View

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/activity/BaseActivity.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/activity/BaseActivity.java
@@ -68,7 +68,8 @@ public abstract class BaseActivity extends Activity implements PanelSlideListene
 
     protected PinnedAdapter pinnedAdapter;
     protected DrawerLayout pinDrawer;
-    protected ListView pinDrawerView;
+    protected View pinDrawerView;
+    protected ListView pinList;
     protected ActionBarDrawerToggle pinDrawerListener;
 
     protected SlidingPaneLayout threadPane;
@@ -153,13 +154,14 @@ public abstract class BaseActivity extends Activity implements PanelSlideListene
         pinDrawer.setDrawerListener(pinDrawerListener);
         pinDrawer.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START);
 
-        pinDrawerView = (ListView) findViewById(R.id.left_drawer);
+        pinDrawerView = findViewById(R.id.left_drawer);
+        pinList = (ListView) findViewById(R.id.pin_list);
 
-        pinnedAdapter = new PinnedAdapter(getActionBar().getThemedContext(), pinDrawerView); // Get the dark theme, not the light one
+        pinnedAdapter = new PinnedAdapter(getActionBar().getThemedContext(), pinList); // Get the dark theme, not the light one
         pinnedAdapter.reload();
-        pinDrawerView.setAdapter(pinnedAdapter);
+        pinList.setAdapter(pinnedAdapter);
 
-        pinDrawerView.setOnItemClickListener(new OnItemClickListener() {
+        pinList.setOnItemClickListener(new OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 Pin pin = pinnedAdapter.getItem(position);
@@ -169,7 +171,7 @@ public abstract class BaseActivity extends Activity implements PanelSlideListene
             }
         });
 
-        pinDrawerView.setOnItemLongClickListener(new OnItemLongClickListener() {
+        pinList.setOnItemLongClickListener(new OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
                 Pin post = pinnedAdapter.getItem(position);
@@ -182,7 +184,7 @@ public abstract class BaseActivity extends Activity implements PanelSlideListene
             }
         });
 
-        SwipeDismissListViewTouchListener touchListener = new SwipeDismissListViewTouchListener(pinDrawerView,
+        SwipeDismissListViewTouchListener touchListener = new SwipeDismissListViewTouchListener(pinList,
                 new DismissCallbacks() {
                     @Override
                     public void onDismiss(ListView listView, int[] reverseSortedPositions) {
@@ -198,9 +200,9 @@ public abstract class BaseActivity extends Activity implements PanelSlideListene
                 }
         );
 
-        pinDrawerView.setOnTouchListener(touchListener);
-        pinDrawerView.setOnScrollListener(touchListener.makeScrollListener());
-        pinDrawerView.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
+        pinList.setOnTouchListener(touchListener);
+        pinList.setOnScrollListener(touchListener.makeScrollListener());
+        pinList.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
     }
 
     @Override

--- a/Clover/app/src/main/res/layout/activity_base.xml
+++ b/Clover/app/src/main/res/layout/activity_base.xml
@@ -41,14 +41,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             style="?board_pane_right_style"/>
     </android.support.v4.widget.SlidingPaneLayout>
 
-    <ListView
+    <FrameLayout
         android:id="@+id/left_drawer"
         android:layout_width="280dp"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:background="#444"
-        android:choiceMode="singleChoice"
-        android:divider="#333"
-        android:dividerHeight="1dp"/>
+        android:background="#444">
+
+        <ListView
+            android:id="@+id/pin_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:choiceMode="singleChoice"
+            android:divider="#333"
+            android:dividerHeight="1dp"/>
+
+        </FrameLayout>
 
 </android.support.v4.widget.DrawerLayout>


### PR DESCRIPTION
This gives the possibility to swipe on the remaining view (the non-ListView) and tuck the drawer back in. It also helps when you're trying to pull the drawer out, that it does not grab a list-view item and disregard the drawer animation for a swipe dismiss animation.

This might need more eyes/hands-on before getting merged. It works fine on my side after using it for about 20 minutes.

Any feedback on this is appreciated!