### PR TITLE
Allow downloading of threads from thread view (without opening image view first)

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/activity/ChanActivity.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/activity/ChanActivity.java
@@ -409,6 +409,7 @@ public class ChanActivity extends BaseActivity implements AdapterView.OnItemSele
         setMenuItemEnabled(menu.findItem(R.id.action_reload_tablet), !slidable);
 
         setMenuItemEnabled(menu.findItem(R.id.action_pin), !slidable || !open);
+        setMenuItemEnabled(menu.findItem(R.id.action_download_album), !slidable || !open);
 
         setMenuItemEnabled(menu.findItem(R.id.action_reply), slidable);
         setMenuItemEnabled(menu.findItem(R.id.action_reply_tablet), !slidable);

--- a/Clover/app/src/main/res/menu/base.xml
+++ b/Clover/app/src/main/res/menu/base.xml
@@ -106,14 +106,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         android:title="@string/action_share" />
 
     <item
+            android:id="@+id/action_download_album"
+            android:orderInCategory="8"
+            android:showAsAction="never"
+            android:title="@string/action_download_album" />
+
+    <item
         android:id="@+id/action_open_browser"
-        android:orderInCategory="8"
+        android:orderInCategory="9"
         android:showAsAction="never"
         android:title="@string/action_open_browser" />
 
     <item
         android:id="@+id/action_board_view_mode"
-        android:orderInCategory="9"
+        android:orderInCategory="10"
         android:showAsAction="never"
         android:title="@string/action_board_view_mode">
         <menu>


### PR DESCRIPTION
I'm downloading lots of threads and thought that it's kinda annoying to be forced to open the image everytime. Hopefully it'll help others as well.