### PR TITLE
Add thread hiding functionality

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ChanApplication.java
+++ b/Clover/app/src/main/java/org/floens/chan/ChanApplication.java
@@ -29,6 +29,7 @@ import com.android.volley.toolbox.Volley;
 import org.floens.chan.chan.ChanUrls;
 import org.floens.chan.core.ChanPreferences;
 import org.floens.chan.core.manager.BoardManager;
+import org.floens.chan.core.manager.HideManager;
 import org.floens.chan.core.manager.ReplyManager;
 import org.floens.chan.core.manager.WatchManager;
 import org.floens.chan.core.net.BitmapLruImageCache;
@@ -56,6 +57,7 @@ public class ChanApplication extends Application {
     private static BoardManager boardManager;
     private static WatchManager watchManager;
     private static ReplyManager replyManager;
+    private static HideManager hideManager;
     private static DatabaseManager databaseManager;
     private static FileCache fileCache;
 
@@ -93,6 +95,8 @@ public class ChanApplication extends Application {
     public static DatabaseManager getDatabaseManager() {
         return databaseManager;
     }
+
+    public static HideManager getHideManager() { return hideManager; }
 
     public static FileCache getFileCache() {
         return fileCache;
@@ -138,6 +142,7 @@ public class ChanApplication extends Application {
         boardManager = new BoardManager();
         watchManager = new WatchManager(this);
         replyManager = new ReplyManager(this);
+        hideManager = new HideManager();
     }
 
     public void activityEnteredForeground() {

--- a/Clover/app/src/main/java/org/floens/chan/core/manager/HideManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/manager/HideManager.java
@@ -1,21 +1,33 @@
+/*
+ * Clover - 4chan browser https://github.com/Floens/Clover/
+ * Copyright (C) 2014  Floens
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.floens.chan.core.manager;
 
 import org.floens.chan.ChanApplication;
 import org.floens.chan.core.model.Hide;
-import org.floens.chan.core.model.Pin;
 import org.floens.chan.core.model.Post;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Created by Allan on 2015-03-08.
- */
 public class HideManager {
-    private final Map<String, Set<Integer>> hiddenThreadsByBoard = new HashMap<String, Set<Integer>>();
+    private final Map<String, Set<Integer>> hiddenThreadsByBoard = new HashMap<>();
 
     public HideManager() {
         updateHidden();
@@ -29,16 +41,13 @@ public class HideManager {
 
     public boolean isHidden(Post post) {
         Set<Integer> boardHidden = hiddenThreadsByBoard.get(post.board);
-        if (boardHidden == null) {
-            return false;
-        }
-        return boardHidden.contains(post.no);
+        return boardHidden != null && boardHidden.contains(post.no);
     }
 
     private void addHideToCache(Hide hide) {
         Set<Integer> boardHidden = hiddenThreadsByBoard.get(hide.board);
         if (boardHidden == null) {
-            Set<Integer> boardHiddden = new HashSet<Integer>();
+            boardHidden = new HashSet<>();
             hiddenThreadsByBoard.put(hide.board, boardHidden);
         }
         boardHidden.add(hide.no);
@@ -48,5 +57,10 @@ public class HideManager {
         for (Hide hide : ChanApplication.getDatabaseManager().getHidden()) {
             addHideToCache(hide);
         }
+    }
+
+    public void resetBoard(String board) {
+        hiddenThreadsByBoard.remove(board);
+        ChanApplication.getDatabaseManager().resetHides(board);
     }
 }

--- a/Clover/app/src/main/java/org/floens/chan/core/manager/HideManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/manager/HideManager.java
@@ -1,0 +1,52 @@
+package org.floens.chan.core.manager;
+
+import org.floens.chan.ChanApplication;
+import org.floens.chan.core.model.Hide;
+import org.floens.chan.core.model.Pin;
+import org.floens.chan.core.model.Post;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by Allan on 2015-03-08.
+ */
+public class HideManager {
+    private final Map<String, Set<Integer>> hiddenThreadsByBoard = new HashMap<String, Set<Integer>>();
+
+    public HideManager() {
+        updateHidden();
+    }
+
+    public void addHide(Post post) {
+        Hide hide = new Hide(post.board, post.no);
+        ChanApplication.getDatabaseManager().addHide(hide);
+        addHideToCache(hide);
+    }
+
+    public boolean isHidden(Post post) {
+        Set<Integer> boardHidden = hiddenThreadsByBoard.get(post.board);
+        if (boardHidden == null) {
+            return false;
+        }
+        return boardHidden.contains(post.no);
+    }
+
+    private void addHideToCache(Hide hide) {
+        Set<Integer> boardHidden = hiddenThreadsByBoard.get(hide.board);
+        if (boardHidden == null) {
+            Set<Integer> boardHiddden = new HashSet<Integer>();
+            hiddenThreadsByBoard.put(hide.board, boardHidden);
+        }
+        boardHidden.add(hide.no);
+    }
+    private void updateHidden() {
+        hiddenThreadsByBoard.clear();
+        for (Hide hide : ChanApplication.getDatabaseManager().getHidden()) {
+            addHideToCache(hide);
+        }
+    }
+}

--- a/Clover/app/src/main/java/org/floens/chan/core/manager/ThreadManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/manager/ThreadManager.java
@@ -292,6 +292,8 @@ public class ThreadManager implements Loader.LoaderListener {
                         break;
                     case 11: // Hide
                         ChanApplication.getHideManager().addHide(post);
+                        threadManagerListener.onRefreshView();
+                        break;
             }
                 return false;
             }

--- a/Clover/app/src/main/java/org/floens/chan/core/manager/ThreadManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/manager/ThreadManager.java
@@ -227,6 +227,7 @@ public class ThreadManager implements Loader.LoaderListener {
 
         if (loader.getLoadable().isBoardMode() || loader.getLoadable().isCatalogMode()) {
             menu.add(Menu.NONE, 9, Menu.NONE, activity.getString(R.string.action_pin));
+            menu.add(Menu.NONE, 11, Menu.NONE, "Hide");
         }
 
         if (loader.getLoadable().isThreadMode()) {
@@ -289,7 +290,9 @@ public class ThreadManager implements Loader.LoaderListener {
                     case 9: // Pin
                         ChanApplication.getWatchManager().addPin(post);
                         break;
-                }
+                    case 11: // Hide
+                        ChanApplication.getHideManager().addHide(post);
+            }
                 return false;
             }
         });

--- a/Clover/app/src/main/java/org/floens/chan/core/model/Hide.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/Hide.java
@@ -1,0 +1,46 @@
+/*
+ * Clover - 4chan browser https://github.com/Floens/Clover/
+ * Copyright (C) 2014  Floens
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.floens.chan.core.model;
+
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+import java.util.Date;
+
+@DatabaseTable
+public class Hide {
+    public Hide() {
+    }
+
+    public Hide(String board, int no) {
+        this.board = board;
+        this.no = no;
+        this.timestamp = new Date();
+    }
+
+    @DatabaseField(generatedId = true)
+    private int id;
+
+    @DatabaseField
+    public String board = "";
+
+    @DatabaseField
+    public int no;
+
+    @DatabaseField
+    public Date timestamp;
+}

--- a/Clover/app/src/main/java/org/floens/chan/database/DatabaseHelper.java
+++ b/Clover/app/src/main/java/org/floens/chan/database/DatabaseHelper.java
@@ -29,6 +29,7 @@ import org.floens.chan.core.model.Board;
 import org.floens.chan.core.model.Loadable;
 import org.floens.chan.core.model.Pin;
 import org.floens.chan.core.model.SavedReply;
+import org.floens.chan.core.model.Hide;
 import org.floens.chan.utils.Logger;
 
 import java.sql.SQLException;
@@ -40,12 +41,13 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
     private static final String TAG = "DatabaseHelper";
 
     private static final String DATABASE_NAME = "ChanDB";
-    private static final int DATABASE_VERSION = 13;
+    private static final int DATABASE_VERSION = 14;
 
     public Dao<Pin, Integer> pinDao;
     public Dao<Loadable, Integer> loadableDao;
     public Dao<SavedReply, Integer> savedDao;
     public Dao<Board, Integer> boardsDao;
+    public Dao<Hide, Integer> hideDao;
 
     private final Context context;
 
@@ -59,6 +61,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             loadableDao = getDao(Loadable.class);
             savedDao = getDao(SavedReply.class);
             boardsDao = getDao(Board.class);
+            hideDao = getDao(Hide.class);
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -71,6 +74,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             TableUtils.createTable(connectionSource, Loadable.class);
             TableUtils.createTable(connectionSource, SavedReply.class);
             TableUtils.createTable(connectionSource, Board.class);
+            TableUtils.createTable(connectionSource, Hide.class);
         } catch (SQLException e) {
             Logger.e(TAG, "Error creating db", e);
             throw new RuntimeException(e);
@@ -127,6 +131,14 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
                 e.printStackTrace();
             }
         }
+
+        if (oldVersion < 14) {
+            try {
+                TableUtils.createTable(connectionSource, Hide.class);
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     public void reset() {
@@ -143,6 +155,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
             TableUtils.dropTable(connectionSource, Loadable.class, true);
             TableUtils.dropTable(connectionSource, SavedReply.class, true);
             TableUtils.dropTable(connectionSource, Board.class, true);
+            TableUtils.dropTable(connectionSource, Hide.class, true);
 
             onCreate(database, connectionSource);
         } catch (SQLException e) {

--- a/Clover/app/src/main/java/org/floens/chan/database/DatabaseManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/database/DatabaseManager.java
@@ -170,14 +170,25 @@ public class DatabaseManager {
         return list;
     }
 
-    public void trimHideTable(long limit) {
+    private void trimHideTable(long limit) {
         try {
             Logger.i(TAG, "Trimming the length of the hide table for " + limit + " rows, was " + helper.hideDao.countOf());
-            helper.savedDao.executeRaw("DELETE FROM hide WHERE id IN " +
+            helper.hideDao.executeRaw("DELETE FROM hide WHERE id IN " +
                     "(SELECT id FROM hide ORDER BY id ASC LIMIT ?)", Long.toString(limit));
             Logger.i(TAG, "The hide table now has " + helper.hideDao.countOf() + " rows");
         } catch (SQLException e) {
             Logger.e(TAG, "Error trimming hide table", e);
+        }
+    }
+
+
+    public void resetHides(String board) {
+        try {
+            Logger.i(TAG, "Resetting hides on board "+board);
+            helper.hideDao.executeRaw("DELETE FROM hide WHERE board=?", board);
+            Logger.i(TAG, "Done resetting hides on board "+board);
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error resetting hides on "+board + "!");
         }
     }
 

--- a/Clover/app/src/main/java/org/floens/chan/database/DatabaseManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/database/DatabaseManager.java
@@ -20,6 +20,7 @@ package org.floens.chan.database;
 import android.content.Context;
 
 import org.floens.chan.core.model.Board;
+import org.floens.chan.core.model.Hide;
 import org.floens.chan.core.model.Pin;
 import org.floens.chan.core.model.SavedReply;
 import org.floens.chan.utils.Logger;
@@ -35,6 +36,9 @@ public class DatabaseManager {
 
     private static final long SAVED_REPLY_TRIM_TRIGGER = 250;
     private static final long SAVED_REPLY_TRIM_COUNT = 50;
+
+    private static final long HIDE_TRIM_TRIGGER = 1000;
+    private static final long HIDE_TRIM_COUNT = 200;
 
     private final DatabaseHelper helper;
     private List<SavedReply> savedReplies;
@@ -166,6 +170,51 @@ public class DatabaseManager {
         return list;
     }
 
+    public void trimHideTable(long limit) {
+        try {
+            Logger.i(TAG, "Trimming the length of the hide table for " + limit + " rows, was " + helper.hideDao.countOf());
+            helper.savedDao.executeRaw("DELETE FROM hide WHERE id IN " +
+                    "(SELECT id FROM hide ORDER BY id ASC LIMIT ?)", Long.toString(limit));
+            Logger.i(TAG, "The hide table now has " + helper.hideDao.countOf() + " rows");
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error trimming hide table", e);
+        }
+    }
+
+    public List<Hide> getHidden() {
+        maybeTrimHiddenThreads();
+        List<Hide> list = null;
+        try {
+            list = helper.hideDao.queryForAll();
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error getting hides from db", e);
+        }
+        return list;
+    }
+
+    private void maybeTrimHiddenThreads() {
+        try {
+            long countHide = helper.hideDao.countOf();
+            if (countHide >= HIDE_TRIM_TRIGGER) {
+                trimHideTable(HIDE_TRIM_COUNT + (countHide - HIDE_TRIM_TRIGGER));
+            }
+        } catch(SQLException e) {
+            Logger.e(TAG, "Error loading hidden threads", e);
+        }
+    }
+
+    public void addHide(Hide hide) {
+        Logger.i(TAG, "Adding Hide for " + hide.board + ", " + hide.no + " to db");
+
+        try {
+            helper.hideDao.create(hide);
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error adding hide", e);
+        }
+
+        maybeTrimHiddenThreads();
+    }
+
     public void setBoards(final List<Board> boards) {
         try {
             helper.boardsDao.callBatchTasks(new Callable<Void>() {
@@ -222,6 +271,7 @@ public class DatabaseManager {
             o += "Pin rows: " + helper.pinDao.countOf() + "\n";
             o += "SavedReply rows: " + helper.savedDao.countOf() + "\n";
             o += "Board rows: " + helper.boardsDao.countOf() + "\n";
+            o += "Hide rows: " + helper.hideDao.countOf() + "\n";
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/Clover/app/src/main/java/org/floens/chan/ui/activity/ChanActivity.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/activity/ChanActivity.java
@@ -423,6 +423,7 @@ public class ChanActivity extends BaseActivity implements AdapterView.OnItemSele
 
         setMenuItemEnabled(menu.findItem(R.id.action_search), slidable);
         setMenuItemEnabled(menu.findItem(R.id.action_search_tablet), !slidable);
+        setMenuItemEnabled(menu.findItem(R.id.action_clear_hidden), !slidable || open);
 
         return super.onPrepareOptionsMenu(menu);
     }
@@ -499,6 +500,10 @@ public class ChanActivity extends BaseActivity implements AdapterView.OnItemSele
                     threadFragment.startFiltering();
                 }
                 return true;
+            case R.id.action_clear_hidden:
+                ChanApplication.getHideManager().resetBoard(boardLoadable.board);
+                boardFragment.onRefreshView();
+                break;
             case R.id.action_search_board:
                 boardFragment.startFiltering();
                 return true;

--- a/Clover/app/src/main/java/org/floens/chan/ui/adapter/PostAdapter.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/adapter/PostAdapter.java
@@ -40,7 +40,6 @@ import org.floens.chan.core.manager.ThreadManager;
 import org.floens.chan.core.model.ChanThread;
 import org.floens.chan.core.model.Loadable;
 import org.floens.chan.core.model.Post;
-import org.floens.chan.ui.ScrollerRunnable;
 import org.floens.chan.ui.view.PostView;
 import org.floens.chan.utils.Utils;
 
@@ -59,6 +58,7 @@ public class PostAdapter extends BaseAdapter implements Filterable {
 
     private final ThreadManager threadManager;
     private final PostAdapterListener listener;
+    private final HideManager hideManager;
 
     /**
      * The list with the original data
@@ -82,6 +82,7 @@ public class PostAdapter extends BaseAdapter implements Filterable {
         this.threadManager = threadManager;
         this.listView = listView;
         this.listener = listener;
+        this.hideManager = ChanApplication.getHideManager();
     }
 
     @Override
@@ -149,19 +150,16 @@ public class PostAdapter extends BaseAdapter implements Filterable {
             @Override
             protected FilterResults performFiltering(CharSequence constraintRaw) {
                 FilterResults results = new FilterResults();
+                List<Post> afterFilter;
+
+                List<Post> all;
+                synchronized (lock) {
+                    all = new ArrayList<>(sourceList);
+                }
 
                 if (TextUtils.isEmpty(constraintRaw)) {
-                    ArrayList<Post> tmp;
-                    synchronized (lock) {
-                        tmp = new ArrayList<>(sourceList);
-                    }
-                    results.values = tmp;
+                    afterFilter = all;
                 } else {
-                    List<Post> all;
-                    synchronized (lock) {
-                        all = new ArrayList<>(sourceList);
-                    }
-
                     List<Post> accepted = new ArrayList<>();
                     String constraint = constraintRaw.toString().toLowerCase(Locale.ENGLISH);
 
@@ -172,9 +170,23 @@ public class PostAdapter extends BaseAdapter implements Filterable {
                         }
                     }
 
-                    results.values = accepted;
+                    afterFilter = accepted;
                 }
 
+                List<Post> afterHide;
+                Loadable l = threadManager.getLoadable();
+                if (l == null || l.isThreadMode()) {
+                    afterHide = afterFilter;
+                } else {
+                    afterHide = new ArrayList<>();
+                    for (Post post : afterFilter) {
+                        if (!hideManager.isHidden(post)) {
+                            afterHide.add(post);
+                        }
+                    }
+                }
+
+                results.values = afterHide;
                 return results;
             }
 
@@ -207,6 +219,10 @@ public class PostAdapter extends BaseAdapter implements Filterable {
         notifyDataSetChanged();
     }
 
+    public void reperformFilter() {
+        setFilter(filter);
+    }
+
     public void setThread(ChanThread thread) {
         synchronized (lock) {
             if (thread.archived) {
@@ -220,16 +236,10 @@ public class PostAdapter extends BaseAdapter implements Filterable {
             sourceList.clear();
             sourceList.addAll(thread.posts);
 
-            if (!isFiltering()) {
-                displayList.clear();
-                HideManager hm = ChanApplication.getHideManager();
-                for (Post post : sourceList) {
-                    if (!hm.isHidden(post)) {
-                        displayList.add(post);
-                    }
-                }
-                setFilter(filter);
-            }
+            displayList.clear();
+            displayList.addAll(thread.posts);
+            setFilter(filter);
+
         }
 
         notifyDataSetChanged();
@@ -246,26 +256,7 @@ public class PostAdapter extends BaseAdapter implements Filterable {
     }
 
     public void scrollToPost(int no) {
-        if (isFiltering()) {
-            pendingScrollToPost = no;
-        } else {
-            notifyDataSetChanged();
-
-            synchronized (lock) {
-                for (int i = 0; i < displayList.size(); i++) {
-                    if (displayList.get(i).no == no) {
-                        if (Math.abs(i - listView.getFirstVisiblePosition()) > 20 || listView.getChildCount() == 0) {
-                            listView.setSelection(i);
-                        } else {
-                            ScrollerRunnable r = new ScrollerRunnable(listView);
-                            r.start(i);
-                        }
-
-                        break;
-                    }
-                }
-            }
-        }
+        pendingScrollToPost = no;
     }
 
     public void setStatusMessage(String loadMessage) {
@@ -296,10 +287,6 @@ public class PostAdapter extends BaseAdapter implements Filterable {
         } else {
             return false;
         }
-    }
-
-    private boolean isFiltering() {
-        return !TextUtils.isEmpty(filter);
     }
 
     public interface PostAdapterListener {

--- a/Clover/app/src/main/java/org/floens/chan/ui/adapter/PostAdapter.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/adapter/PostAdapter.java
@@ -32,7 +32,9 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import org.floens.chan.ChanApplication;
 import org.floens.chan.R;
+import org.floens.chan.core.manager.HideManager;
 import org.floens.chan.core.loader.Loader;
 import org.floens.chan.core.manager.ThreadManager;
 import org.floens.chan.core.model.ChanThread;
@@ -220,8 +222,12 @@ public class PostAdapter extends BaseAdapter implements Filterable {
 
             if (!isFiltering()) {
                 displayList.clear();
-                displayList.addAll(sourceList);
-            } else {
+                HideManager hm = ChanApplication.getHideManager();
+                for (Post post : sourceList) {
+                    if (!hm.isHidden(post)) {
+                        displayList.add(post);
+                    }
+                }
                 setFilter(filter);
             }
         }

--- a/Clover/app/src/main/java/org/floens/chan/ui/fragment/ThreadFragment.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/fragment/ThreadFragment.java
@@ -202,7 +202,7 @@ public class ThreadFragment extends Fragment implements ThreadManager.ThreadMana
     @Override
     public void onRefreshView() {
         if (postAdapter != null) {
-            postAdapter.notifyDataSetChanged();
+            postAdapter.reperformFilter();
         }
     }
 

--- a/Clover/app/src/main/res/menu/base.xml
+++ b/Clover/app/src/main/res/menu/base.xml
@@ -129,6 +129,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     </item>
 
     <item
+        android:id="@+id/action_clear_hidden"
+        android:orderInCategory="10"
+        android:showAsAction="never"
+        android:title="@string/action_reset_hidden"/>
+
+    <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
         android:showAsAction="never"

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="ok">OK</string>
 
     <string name="action_settings">Settings</string>
+    <string name="action_reset_hidden">Reset Hidden</string>
     <string name="action_reload">Reload</string>
     <string name="action_reload_board">Reload board</string>
     <string name="action_reload_thread">Reload thread</string>


### PR DESCRIPTION
This set of commits adds the ability to "hide" threads. The set of hidden threads are stored in a new database table, and the hiding uses roughly the same mechanism as the filtering mechanism. This is a feature that I have wanted in Clover for a while, so I decided to add it myself.

Things added:
  - new DB table for hidden threads
  - new button in board grid / list view for 'hide thread', right next to pin
  - new button for 'reset hidden threads' in context menu, which resets the hidden threads for the current board.

It would be nice to also have a 'show hidden' option, but I wouldn't personally use it, so I didn't add it.

There is also an issue that causes some thumbnails to show up incorrectly in the grid/list views after hiding a thread and then hitting the 'refresh' button. I tried to debug this issue but I am not sure what the cause of it would be. My hunch is that it has something to do with the `CustomNetworkImageView` for the `PostView` not getting reset correctly. This issue needs to be fixed before merging in, and any help would be appreciated.