### PR TITLE
Fix resource leak in ImageSaver.java

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/utils/ImageSaver.java
+++ b/Clover/app/src/main/java/org/floens/chan/utils/ImageSaver.java
@@ -255,9 +255,10 @@ public class ImageSaver {
         try {
             is = new FileInputStream(source);
             os = new FileOutputStream(destination);
-            IOUtils.copy(new FileInputStream(source), new FileOutputStream(destination));
+            IOUtils.copy(is, os);
         } catch (IOException e) {
             res = false;
+        } finally {
             IOUtils.closeQuietly(is);
             IOUtils.closeQuietly(os);
         }


### PR DESCRIPTION
While investigating into problems with Clover crashing on my tablet (looks like a memory leak somewhere in the App Store version) I decided to look at the dev branch and found that there was 4 objects leaking in the ImageSaver. I've also added Square's LeakCanary to my local tree and haven't found any leaks with that yet in the dev branch. I'll open another pull request with that change later if you are interested.