### PR TITLE
Update the post_details_color so that it can be more easily seen on dark themes

### DIFF
--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -88,7 +88,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="post_saved_reply_color">#ff5C5C5C</item>
         <item name="post_highlighted_color">#ff444444</item>
         <item name="post_subject_color">#ff625cff</item>
-        <item name="post_details_color">#ff646464</item>
+        <item name="post_details_color">#ffc5c8c6</item>
         <item name="post_link_color">#ff625cff</item>
         <item name="post_spoiler_color">#ff000000</item>
         <item name="post_id_background_light">#00000000</item>
@@ -157,7 +157,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="post_link_color">#ff5F89AC</item>
         <item name="post_highlight_quote_color">#2b435a</item>
         <item name="post_subject_color">#ffb294bb</item>
-        <item name="post_details_color">#ffc5c8c6</item>
         <item name="post_inline_quote_color">#ffb5bd68</item>
 
     </style>


### PR DESCRIPTION
On Dark (and inherited) themes, I found the post details and time stamp hard to read for posts that the user has posted (saved posts). The background highlight colour and the post details colour are very similar hence the difficulty in reading. I've borrowed a colour from another theme (Tomorrow) for the `post_details_color` variable - obviously this is very subjective but I feel this strikes a better balance than before. 

### Before
![before](https://cloud.githubusercontent.com/assets/4974178/12368898/3e945b96-bbe8-11e5-9e48-96f68f3cce53.png)

### After
![after](https://cloud.githubusercontent.com/assets/4974178/12368897/3e92a99a-bbe8-11e5-8e96-ed625c280040.png)


