### PR TITLE
Advanced option to show/hide Anonymous username

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/chan/ChanParser.java
+++ b/Clover/app/src/main/java/org/floens/chan/chan/ChanParser.java
@@ -133,7 +133,7 @@ public class ChanParser {
             }
         }
 
-        if (!TextUtils.isEmpty(post.name) && !post.name.equals("Anonymous")) {
+        if (!TextUtils.isEmpty(post.name) && (!post.name.equals("Anonymous") || ChanSettings.showAnonymousName.get())) {
             post.nameSpan = new SpannableString(post.name);
             post.nameSpan.setSpan(new ForegroundColorSpanHashed(theme.nameColor), 0, post.nameSpan.length(), 0);
         }

--- a/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
@@ -86,6 +86,7 @@ public class ChanSettings {
     public static final BooleanSetting enableReplyFab;
     public static final BooleanSetting anonymize;
     public static final BooleanSetting anonymizeIds;
+    public static final BooleanSetting showAnonymousName;
     public static final BooleanSetting repliesButtonsBottom;
     public static final BooleanSetting confirmExit;
     public static final BooleanSetting tapNoReply;
@@ -159,6 +160,7 @@ public class ChanSettings {
         enableReplyFab = new BooleanSetting(p, "preference_enable_reply_fab", true);
         anonymize = new BooleanSetting(p, "preference_anonymize", false);
         anonymizeIds = new BooleanSetting(p, "preference_anonymize_ids", false);
+        showAnonymousName = new BooleanSetting(p, "preference_show_anonymous_name", false);
         repliesButtonsBottom = new BooleanSetting(p, "preference_buttons_bottom", false);
         confirmExit = new BooleanSetting(p, "preference_confirm_exit", false);
         tapNoReply = new BooleanSetting(p, "preference_tap_no_reply", false);

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/AdvancedSettingsController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/AdvancedSettingsController.java
@@ -124,6 +124,7 @@ public class AdvancedSettingsController extends SettingsController {
         enableReplyFab = settings.add(new BooleanSettingView(this, ChanSettings.enableReplyFab, R.string.setting_enable_reply_fab, R.string.setting_enable_reply_fab_description));
         settings.add(new BooleanSettingView(this, ChanSettings.anonymize, R.string.setting_anonymize, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.anonymizeIds, R.string.setting_anonymize_ids, 0));
+        settings.add(new BooleanSettingView(this, ChanSettings.showAnonymousName, R.string.setting_show_anonymous_name, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.repliesButtonsBottom, R.string.setting_buttons_bottom, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.confirmExit, R.string.setting_confirm_exit, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.tapNoReply, R.string.setting_tap_no_rely, 0));

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -376,6 +376,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="setting_enable_reply_fab_description">Disabling replaces it with a menu option</string>
     <string name="setting_anonymize">Make everyone Anonymous</string>
     <string name="setting_anonymize_ids">Hide IDs</string>
+    <string name="setting_show_anonymous_name">Show Anonymous username</string>
     <string name="setting_buttons_bottom">Reply buttons on the bottom</string>
     <string name="setting_confirm_exit">Confirm before exit</string>
     <string name="setting_confirm_exit_title">Confirm exit</string>


### PR DESCRIPTION
Shows the Anonymous username in post cell when that post is created by anonymous user.
Can be toggled in the advanced options under 'Show Anonymous username'. Defaults to off.

Brought up by #148 