### PR TITLE
Change repository: mavenCentral -> jcenter

### DIFF
--- a/Clover/build.gradle
+++ b/Clover/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.1.0-alpha5'
@@ -10,6 +10,6 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }


### PR DESCRIPTION
Fix 'could not find dependency gradle:2.1.0-alpha5' by switching repository from mavenCentral -> jcenter. 
This fixes the failed build.

I'm not sure if you preemptively updated the version for when mavenCentral finally does get the latest version.