### PR TITLE
Add ability to clear saved replies/reply history

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/database/DatabaseManager.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/database/DatabaseManager.java
@@ -282,6 +282,59 @@ public class DatabaseManager {
         return list;
     }
 
+    /**
+     * Clears all stored saved replies
+     */
+    public void clearSavedReplyHistory() {
+        try {
+            TransactionManager.callInTransaction(helper.getConnectionSource(), new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    List<SavedReply> replyList = getSavedReplyList();
+                    for (SavedReply savedReply : replyList) {
+                        removeSavedReply(savedReply);
+                    }
+
+                    return null;
+                }
+            });
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error clearing saved replies", e);
+        }
+    }
+
+    /**
+     * Deletes a {@link SavedReply} from the saved table.
+     *
+     * @param savedReply SavedReply to delete
+     */
+    public void removeSavedReply(SavedReply savedReply) {
+        try {
+            helper.savedDao.delete(savedReply);
+            savedReplies.remove(savedReply);
+            savedRepliesIds.remove(savedReply.no);
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error removing saved reply from db", e);
+        }
+    }
+
+    /**
+     * Get a list of {@link SavedReply} entries from the saved table.
+     *
+     * @return List of SavedReply
+     */
+    public List<SavedReply> getSavedReplyList() {
+        List<SavedReply> list = null;
+        try {
+            QueryBuilder<SavedReply, Integer> savedReplyQuery = helper.savedDao.queryBuilder();
+            list = savedReplyQuery.query();
+        } catch (SQLException e) {
+            Logger.e(TAG, "Error getting saved replies from db", e);
+        }
+
+        return list;
+    }
+
     public void addOrUpdateFilter(Filter filter) {
         try {
             helper.filterDao.createOrUpdate(filter);

--- a/Clover/app/src/main/java/org/floens/chan/core/model/SavedReply.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/SavedReply.java
@@ -31,6 +31,15 @@ public class SavedReply {
         this.password = password;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) return false;
+        if (obj == this) return true;
+        if (!(obj instanceof SavedReply)) return false;
+        SavedReply o = (SavedReply) obj;
+        return o.board.equals(this.board) && o.id == this.id && o.no == this.no && o.password.equals(this.password);
+    }
+
     @DatabaseField(generatedId = true)
     private int id;
 

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/HistoryController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/HistoryController.java
@@ -54,6 +54,7 @@ import static org.floens.chan.utils.AndroidUtils.dp;
 public class HistoryController extends Controller implements CompoundButton.OnCheckedChangeListener, ToolbarMenuItem.ToolbarMenuItemCallback, ToolbarNavigationController.ToolbarSearchCallback {
     private static final int SEARCH_ID = 1;
     private static final int CLEAR_ID = 101;
+    private static final int SAVED_REPLY_CLEAR_ID = 102;
 
     private DatabaseManager databaseManager;
     private RecyclerView recyclerView;
@@ -72,6 +73,7 @@ public class HistoryController extends Controller implements CompoundButton.OnCh
         navigationItem.setTitle(R.string.history_screen);
         List<FloatingMenuItem> items = new ArrayList<>();
         items.add(new FloatingMenuItem(CLEAR_ID, R.string.history_clear));
+        items.add(new FloatingMenuItem(SAVED_REPLY_CLEAR_ID, R.string.saved_reply_clear));
         navigationItem.menu = new ToolbarMenu(context);
         navigationItem.menu.addItem(new ToolbarMenuItem(context, this, SEARCH_ID, R.drawable.ic_search_white_24dp));
         navigationItem.createOverflow(context, this, items);
@@ -113,6 +115,18 @@ public class HistoryController extends Controller implements CompoundButton.OnCh
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             databaseManager.clearHistory();
+                            adapter.load();
+                        }
+                    })
+                    .show();
+        } else if ((Integer) item.getId() == SAVED_REPLY_CLEAR_ID) {
+            new AlertDialog.Builder(context)
+                    .setTitle(R.string.saved_reply_clear_confirm)
+                    .setNegativeButton(R.string.cancel, null)
+                    .setPositiveButton(R.string.saved_reply_clear_confirm_button, new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            databaseManager.clearSavedReplyHistory();
                             adapter.load();
                         }
                     })

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -229,6 +229,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="history_clear_confirm_button">Clear</string>
     <string name="history_toggle_hint">Enable or disable history</string>
 
+    <string name="saved_reply_clear">Clear post history</string>
+    <string name="saved_reply_clear_confirm">Clear post history?</string>
+    <string name="saved_reply_clear_confirm_button">Clear</string>
+
     <string name="drawer_board">Board</string>
     <string name="drawer_catalog">Catalog</string>
     <string name="drawer_pinned">Bookmarked threads</string>


### PR DESCRIPTION
In a sub-menu located under the 'Clear history' option in the History view.
Requires a thread refresh to take effect

Feature brought up in #160 