### PR TITLE
Update gradle to 2.1.0

### DIFF
--- a/Clover/build.gradle
+++ b/Clover/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha5'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 


### PR DESCRIPTION
Android studio is being annoying, and gets angry about using 2.1.0-alpha5 (for some reason) and sets gradle version to 2.1.0.
Tested with a build and quick smoke test.