### PR TITLE
Add Reveal Image Spoilers in advanced options

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/model/Post.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/Post.java
@@ -23,6 +23,7 @@ import android.text.TextUtils;
 import org.floens.chan.Chan;
 import org.floens.chan.chan.ChanParser;
 import org.floens.chan.chan.ChanUrls;
+import org.floens.chan.core.settings.ChanSettings;
 import org.jsoup.parser.Parser;
 
 import java.util.ArrayList;
@@ -162,7 +163,7 @@ public class Post {
             imageUrl = ChanUrls.getImageUrl(board, Long.toString(tim), ext);
             filename = Parser.unescapeEntities(filename, false);
 
-            if (spoiler) {
+            if (spoiler && !ChanSettings.revealImageSpoilers.get()) {
                 Board b = Chan.getBoardManager().getBoardByCode(board);
                 if (b != null && b.customSpoilers >= 0) {
                     thumbnailUrl = ChanUrls.getCustomSpoilerUrl(board, random.nextInt(b.customSpoilers) + 1);

--- a/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
@@ -187,7 +187,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
     private void onLowResInCenter() {
         PostImage postImage = images.get(selectedPosition);
 
-        if (imageAutoLoad(postImage) && !postImage.spoiler) {
+        if (imageAutoLoad(postImage) && (!postImage.spoiler || ChanSettings.revealImageSpoilers.get())) {
             if (postImage.type == PostImage.Type.STATIC) {
                 callback.setImageMode(postImage, MultiImageView.Mode.BIGIMAGE);
             } else if (postImage.type == PostImage.Type.GIF) {

--- a/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
@@ -117,6 +117,7 @@ public class ChanSettings {
     public static final BooleanSetting anonymize;
     public static final BooleanSetting anonymizeIds;
     public static final BooleanSetting showAnonymousName;
+    public static final BooleanSetting revealImageSpoilers;
     public static final BooleanSetting repliesButtonsBottom;
     public static final BooleanSetting confirmExit;
     public static final BooleanSetting tapNoReply;
@@ -205,6 +206,7 @@ public class ChanSettings {
         anonymize = new BooleanSetting(p, "preference_anonymize", false);
         anonymizeIds = new BooleanSetting(p, "preference_anonymize_ids", false);
         showAnonymousName = new BooleanSetting(p, "preference_show_anonymous_name", false);
+        revealImageSpoilers = new BooleanSetting(p, "preference_reveal_image_spoilers", false);
         repliesButtonsBottom = new BooleanSetting(p, "preference_buttons_bottom", false);
         confirmExit = new BooleanSetting(p, "preference_confirm_exit", false);
         tapNoReply = new BooleanSetting(p, "preference_tap_no_reply", false);

--- a/Clover/app/src/main/java/org/floens/chan/ui/cell/AlbumViewCell.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/cell/AlbumViewCell.java
@@ -24,6 +24,7 @@ import android.widget.TextView;
 
 import org.floens.chan.R;
 import org.floens.chan.core.model.PostImage;
+import org.floens.chan.core.settings.ChanSettings;
 import org.floens.chan.ui.view.PostImageThumbnailView;
 import org.floens.chan.ui.view.ThumbnailView;
 import org.floens.chan.utils.AndroidUtils;
@@ -62,7 +63,7 @@ public class AlbumViewCell extends FrameLayout {
         int thumbnailSize = getDimen(getContext(), R.dimen.cell_post_thumbnail_size);
         thumbnailView.setPostImage(postImage, thumbnailSize, thumbnailSize);
 
-        String filename = postImage.spoiler ? getString(R.string.image_spoiler_filename) : postImage.filename + "." + postImage.extension;
+        String filename = postImage.spoiler && !ChanSettings.revealImageSpoilers.get() ? getString(R.string.image_spoiler_filename) : postImage.filename + "." + postImage.extension;
         String details = postImage.extension.toUpperCase() + " " + postImage.imageWidth + "x" + postImage.imageHeight +
                 " " + AndroidUtils.getReadableFileSize(postImage.size, false);
         text.setText(details);

--- a/Clover/app/src/main/java/org/floens/chan/ui/cell/PostCell.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/cell/PostCell.java
@@ -373,7 +373,7 @@ public class PostCell extends LinearLayout implements PostCellInterface {
 
             boolean postFileName = ChanSettings.postFilename.get();
             if (postFileName) {
-                String filename = image.spoiler ? getString(R.string.image_spoiler_filename) : image.filename + "." + image.extension;
+                String filename = image.spoiler && !ChanSettings.revealImageSpoilers.get() ? getString(R.string.image_spoiler_filename) : image.filename + "." + image.extension;
                 SpannableString fileInfo = new SpannableString("\n" + filename);
                 fileInfo.setSpan(new ForegroundColorSpanHashed(theme.detailsColor), 0, fileInfo.length(), 0);
                 fileInfo.setSpan(new AbsoluteSizeSpanHashed(detailsSizePx), 0, fileInfo.length(), 0);

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/AdvancedSettingsController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/AdvancedSettingsController.java
@@ -123,6 +123,7 @@ public class AdvancedSettingsController extends SettingsController {
         settings.add(new BooleanSettingView(this, ChanSettings.anonymize, R.string.setting_anonymize, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.anonymizeIds, R.string.setting_anonymize_ids, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.showAnonymousName, R.string.setting_show_anonymous_name, 0));
+        settings.add(new BooleanSettingView(this, ChanSettings.revealImageSpoilers, R.string.settings_reveal_image_spoilers, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.repliesButtonsBottom, R.string.setting_buttons_bottom, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.confirmExit, R.string.setting_confirm_exit, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.tapNoReply, R.string.setting_tap_no_rely, 0));

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
@@ -277,7 +277,7 @@ public class ImageViewerController extends Controller implements ImageViewerPres
     }
 
     public void setTitle(PostImage postImage, int index, int count, boolean spoiler) {
-        if (spoiler) {
+        if (spoiler && !ChanSettings.revealImageSpoilers.get()) {
             navigationItem.title = getString(R.string.image_spoiler_filename);
         } else {
             navigationItem.title = postImage.filename + "." + postImage.extension;

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -410,6 +410,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="setting_anonymize">Make everyone Anonymous</string>
     <string name="setting_anonymize_ids">Hide IDs</string>
     <string name="setting_show_anonymous_name">Show Anonymous username</string>
+    <string name="settings_reveal_image_spoilers">Reveal image spoilers</string>
     <string name="setting_buttons_bottom">Reply buttons on the bottom</string>
     <string name="setting_confirm_exit">Confirm before exit</string>
     <string name="setting_confirm_exit_title">Confirm exit</string>


### PR DESCRIPTION
I think I covered all the cases and got the logic right...
(my manual testing had it working correctly for each scenario)

This option reveals spoiled images in the board/catalog view, thumbnail, album view, and image view. As well as handles the file name and nav title.

Feature requested in #190 