### PR TITLE
Add advanced option to reveal spoiler text

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/model/PostLinkable.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/PostLinkable.java
@@ -22,6 +22,7 @@ import android.text.TextPaint;
 import android.text.style.ClickableSpan;
 import android.view.View;
 
+import org.floens.chan.core.settings.ChanSettings;
 import org.floens.chan.ui.cell.PostCell;
 import org.floens.chan.ui.theme.Theme;
 
@@ -41,7 +42,7 @@ public class PostLinkable extends ClickableSpan {
     public final Object value;
     public final Type type;
 
-    private boolean spoilerVisible = false;
+    private boolean spoilerVisible = ChanSettings.revealTextSpoilers.get();
     private int markedNo = -1;
 
     public PostLinkable(Theme theme, Post post, String key, Object value, Type type) {
@@ -78,10 +79,12 @@ public class PostLinkable extends ClickableSpan {
 
             ds.setUnderlineText(true);
         } else if (type == Type.SPOILER) {
+            ds.bgColor = theme.spoilerColor;
+            ds.setUnderlineText(false);
             if (!spoilerVisible) {
                 ds.setColor(theme.spoilerColor);
-                ds.bgColor = theme.spoilerColor;
-                ds.setUnderlineText(false);
+            } else {
+                ds.setColor(theme.textColorRevealSpoiler);
             }
         }
     }

--- a/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
@@ -117,6 +117,7 @@ public class ChanSettings {
     public static final BooleanSetting anonymize;
     public static final BooleanSetting anonymizeIds;
     public static final BooleanSetting showAnonymousName;
+    public static final BooleanSetting revealTextSpoilers;
     public static final BooleanSetting repliesButtonsBottom;
     public static final BooleanSetting confirmExit;
     public static final BooleanSetting tapNoReply;
@@ -205,6 +206,7 @@ public class ChanSettings {
         anonymize = new BooleanSetting(p, "preference_anonymize", false);
         anonymizeIds = new BooleanSetting(p, "preference_anonymize_ids", false);
         showAnonymousName = new BooleanSetting(p, "preference_show_anonymous_name", false);
+        revealTextSpoilers = new BooleanSetting(p, "preference_reveal_text_spoilers", false);
         repliesButtonsBottom = new BooleanSetting(p, "preference_buttons_bottom", false);
         confirmExit = new BooleanSetting(p, "preference_confirm_exit", false);
         tapNoReply = new BooleanSetting(p, "preference_tap_no_reply", false);

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/AdvancedSettingsController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/AdvancedSettingsController.java
@@ -123,6 +123,7 @@ public class AdvancedSettingsController extends SettingsController {
         settings.add(new BooleanSettingView(this, ChanSettings.anonymize, R.string.setting_anonymize, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.anonymizeIds, R.string.setting_anonymize_ids, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.showAnonymousName, R.string.setting_show_anonymous_name, 0));
+        settings.add(new BooleanSettingView(this, ChanSettings.revealTextSpoilers, R.string.settings_reveal_text_spoilers, R.string.settings_reveal_text_spoilers_description));
         settings.add(new BooleanSettingView(this, ChanSettings.repliesButtonsBottom, R.string.setting_buttons_bottom, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.confirmExit, R.string.setting_confirm_exit, 0));
         settings.add(new BooleanSettingView(this, ChanSettings.tapNoReply, R.string.setting_tap_no_rely, 0));

--- a/Clover/app/src/main/java/org/floens/chan/ui/theme/Theme.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/theme/Theme.java
@@ -58,6 +58,7 @@ public class Theme {
     public int highlightedColor;
     public int savedReplyColor;
     public int selectedColor;
+    public int textColorRevealSpoiler;
 
     public ThemeDrawable settingsDrawable;
     public ThemeDrawable imageDrawable;
@@ -120,7 +121,8 @@ public class Theme {
                 R.attr.post_selected_color,
                 R.attr.text_color_primary,
                 R.attr.text_color_secondary,
-                R.attr.text_color_hint
+                R.attr.text_color_hint,
+                R.attr.text_color_reveal_spoiler
         });
 
         quoteColor = ta.getColor(0, 0);
@@ -140,6 +142,7 @@ public class Theme {
         textPrimary = ta.getColor(14, 0);
         textSecondary = ta.getColor(15, 0);
         textHint = ta.getColor(16, 0);
+        textColorRevealSpoiler = ta.getColor(17, 0);
 
         ta.recycle();
     }

--- a/Clover/app/src/main/res/values/attrs.xml
+++ b/Clover/app/src/main/res/values/attrs.xml
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <attr name="text_color_primary" format="color" />
     <attr name="text_color_secondary" format="color" />
     <attr name="text_color_hint" format="color" />
+    <attr name="text_color_reveal_spoiler" format="color" />
 
     <attr name="backcolor" format="color" />
     <attr name="backcolor_secondary" format="color" />

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -410,6 +410,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="setting_anonymize">Make everyone Anonymous</string>
     <string name="setting_anonymize_ids">Hide IDs</string>
     <string name="setting_show_anonymous_name">Show Anonymous username</string>
+    <string name="settings_reveal_text_spoilers">Reveal text spoilers</string>
+    <string name="settings_reveal_text_spoilers_description">Makes the spoiler text appear clicked</string>
     <string name="setting_buttons_bottom">Reply buttons on the bottom</string>
     <string name="setting_confirm_exit">Confirm before exit</string>
     <string name="setting_confirm_exit_title">Confirm exit</string>

--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -39,6 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="text_color_primary">#DE000000</item>
         <item name="text_color_secondary">#89000000</item>
         <item name="text_color_hint">#42000000</item>
+        <item name="text_color_reveal_spoiler">#ffffffff</item>
 
         <item name="post_name_color">#ff117743</item>
         <item name="post_subject_color">#ff0F0C5D</item>


### PR DESCRIPTION
Gives the spoiler text the appearance that is has already been clicked.

This changes the spoiler text to act similar to 4chanx's spoiler text, where the spoilered text will keep the same background color when revealed, and only the text color changes. This makes sense with the 'Reveal spoiler text' option so that you can still tell the difference between normal text and spoiler text for 'context'.

Also added a 'text_color_reveal_spoiler' since the spoiler text always has the spoiler background, even when revealed. I created a new color instead of using a preexisting color (such as textPrimary) due to some of the text colors on the lighter themes being very similar to spoilerColor (ie: black), making it hard to see when revealed.