### PR TITLE
Reveal image spoiler refactor

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/model/Post.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/Post.java
@@ -23,7 +23,6 @@ import android.text.TextUtils;
 import org.floens.chan.Chan;
 import org.floens.chan.chan.ChanParser;
 import org.floens.chan.chan.ChanUrls;
-import org.floens.chan.core.settings.ChanSettings;
 import org.jsoup.parser.Parser;
 
 import java.util.ArrayList;
@@ -163,7 +162,7 @@ public class Post {
             imageUrl = ChanUrls.getImageUrl(board, Long.toString(tim), ext);
             filename = Parser.unescapeEntities(filename, false);
 
-            if (spoiler && !ChanSettings.revealImageSpoilers.get()) {
+            if (spoiler) {
                 Board b = Chan.getBoardManager().getBoardByCode(board);
                 if (b != null && b.customSpoilers >= 0) {
                     thumbnailUrl = ChanUrls.getCustomSpoilerUrl(board, random.nextInt(b.customSpoilers) + 1);

--- a/Clover/app/src/main/java/org/floens/chan/core/net/ChanReaderRequest.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/net/ChanReaderRequest.java
@@ -30,6 +30,7 @@ import org.floens.chan.core.manager.FilterEngine;
 import org.floens.chan.core.model.Filter;
 import org.floens.chan.core.model.Loadable;
 import org.floens.chan.core.model.Post;
+import org.floens.chan.core.settings.ChanSettings;
 import org.floens.chan.utils.Time;
 
 import java.util.ArrayList;
@@ -410,7 +411,7 @@ public class ChanReaderRequest extends JsonReaderRequest<ChanReaderRequest.ChanR
                     post.images = reader.nextInt();
                     break;
                 case "spoiler":
-                    post.spoiler = reader.nextInt() == 1;
+                    post.spoiler = reader.nextInt() == 1 && !ChanSettings.revealImageSpoilers.get();
                     break;
                 case "unique_ips":
                     post.uniqueIps = reader.nextInt();

--- a/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
@@ -187,7 +187,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
     private void onLowResInCenter() {
         PostImage postImage = images.get(selectedPosition);
 
-        if (imageAutoLoad(postImage) && (!postImage.spoiler || ChanSettings.revealImageSpoilers.get())) {
+        if (imageAutoLoad(postImage) && !postImage.spoiler) {
             if (postImage.type == PostImage.Type.STATIC) {
                 callback.setImageMode(postImage, MultiImageView.Mode.BIGIMAGE);
             } else if (postImage.type == PostImage.Type.GIF) {

--- a/Clover/app/src/main/java/org/floens/chan/ui/cell/AlbumViewCell.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/cell/AlbumViewCell.java
@@ -24,7 +24,6 @@ import android.widget.TextView;
 
 import org.floens.chan.R;
 import org.floens.chan.core.model.PostImage;
-import org.floens.chan.core.settings.ChanSettings;
 import org.floens.chan.ui.view.PostImageThumbnailView;
 import org.floens.chan.ui.view.ThumbnailView;
 import org.floens.chan.utils.AndroidUtils;
@@ -63,7 +62,7 @@ public class AlbumViewCell extends FrameLayout {
         int thumbnailSize = getDimen(getContext(), R.dimen.cell_post_thumbnail_size);
         thumbnailView.setPostImage(postImage, thumbnailSize, thumbnailSize);
 
-        String filename = postImage.spoiler && !ChanSettings.revealImageSpoilers.get() ? getString(R.string.image_spoiler_filename) : postImage.filename + "." + postImage.extension;
+        String filename = postImage.spoiler ? getString(R.string.image_spoiler_filename) : postImage.filename + "." + postImage.extension;
         String details = postImage.extension.toUpperCase() + " " + postImage.imageWidth + "x" + postImage.imageHeight +
                 " " + AndroidUtils.getReadableFileSize(postImage.size, false);
         text.setText(details);

--- a/Clover/app/src/main/java/org/floens/chan/ui/cell/PostCell.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/cell/PostCell.java
@@ -373,7 +373,7 @@ public class PostCell extends LinearLayout implements PostCellInterface {
 
             boolean postFileName = ChanSettings.postFilename.get();
             if (postFileName) {
-                String filename = image.spoiler && !ChanSettings.revealImageSpoilers.get() ? getString(R.string.image_spoiler_filename) : image.filename + "." + image.extension;
+                String filename = image.spoiler ? getString(R.string.image_spoiler_filename) : image.filename + "." + image.extension;
                 SpannableString fileInfo = new SpannableString("\n" + filename);
                 fileInfo.setSpan(new ForegroundColorSpanHashed(theme.detailsColor), 0, fileInfo.length(), 0);
                 fileInfo.setSpan(new AbsoluteSizeSpanHashed(detailsSizePx), 0, fileInfo.length(), 0);

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
@@ -277,7 +277,7 @@ public class ImageViewerController extends Controller implements ImageViewerPres
     }
 
     public void setTitle(PostImage postImage, int index, int count, boolean spoiler) {
-        if (spoiler && !ChanSettings.revealImageSpoilers.get()) {
+        if (spoiler) {
             navigationItem.title = getString(R.string.image_spoiler_filename);
         } else {
             navigationItem.title = postImage.filename + "." + postImage.extension;


### PR DESCRIPTION
Reveal image spoiler setting is checked at the parse level
The check is only made once, then the value is propagated down.
Reduces amount of code, simplifies booleans.


Implementing it this way makes much more sense, of course. Thank you for the suggestion ! (I think this is the solution you were thinking about in #193) 