### PR TITLE
Disable autocorrect for legacy captcha input field

### DIFF
--- a/Clover/app/src/main/res/layout/layout_captcha_legacy.xml
+++ b/Clover/app/src/main/res/layout/layout_captcha_legacy.xml
@@ -37,6 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:hint="@string/reply_captcha_text"
+            android:inputType="textFilter"
             android:singleLine="true"
             android:textSize="16sp" />
 


### PR DESCRIPTION
Sometimes the legacy captcha gives weird words/capitalization, and having the word auto corrected after typing it carefully sucks.

Maybe it's just me though :ghost: 