### PR TITLE
Change the captcha keyboard to textVisiblePassword

### DIFF
--- a/Clover/app/src/main/res/layout/layout_captcha_legacy.xml
+++ b/Clover/app/src/main/res/layout/layout_captcha_legacy.xml
@@ -37,7 +37,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:hint="@string/reply_captcha_text"
-            android:inputType="textFilter"
+            android:inputType="textVisiblePassword"
             android:singleLine="true"
             android:textSize="16sp" />
 


### PR DESCRIPTION
This is an advantage because it replaces the autocorrect area of the keyboard with
numbers (which is useful for number only captchas)

Shamelessly stealing idea from thread. Feeling obliged to change it because I changed the keyboard earlier from autocorrect -> non autocorrect, and this is a much better idea than mine.