### PR TITLE
Change the repliesTo for post from list -> set.

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/model/Post.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/Post.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -104,9 +106,9 @@ public class Post {
 
 
     /**
-     * This post replies to the these ids. Is an unmodifiable list after finish().
+     * This post replies to the these ids. Is an unmodifiable set after finish().
      */
-    public List<Integer> repliesTo = new ArrayList<>();
+    public Set<Integer> repliesTo = new TreeSet<>();
 
     public final ArrayList<PostLinkable> linkables = new ArrayList<>();
 
@@ -182,7 +184,7 @@ public class Post {
 
         ChanParser.getInstance().parse(this);
 
-        repliesTo = Collections.unmodifiableList(repliesTo);
+        repliesTo = Collections.unmodifiableSet(repliesTo);
 
         return true;
     }


### PR DESCRIPTION
This removes the bug when a post seems to have more replies than it should due to people quoting the post number more than once in their post.
This also fixes the bug where the post1 that quotes post2 multiple times, post1 shows up in the list of replies for post2 multiple times.

ie, a single post that looks like:
```javascript
>>3875022
>>3875022
>>3875022
>>3875022
```
Made the post numbered 3875022 think it had 4 replies, when in actuality it was only one.

My tests involved replying to myself from pc -> phone, and phone -> pc and everything matched up correctly. Let me know if you see any other issues or test cases that I might be missing.