### PR TITLE
Remove google play link

### DIFF
--- a/Clover/app/src/main/res/values/private_strings.xml
+++ b/Clover/app/src/main/res/values/private_strings.xml
@@ -5,10 +5,6 @@
         <item>Give a PayPal or Bitcoin donation to the Clover developer</item>
         <item>https://floens.github.io/Clover/#donate</item>
 
-        <item>Rate Clover</item>
-        <item>Rate Clover on Google Play</item>
-        <item>https://play.google.com/store/apps/details?id=org.floens.chan</item>
-
         <item>Find Clover on GitHub</item>
         <item>View the source code and give feedback</item>
         <item>https://github.com/Floens/Clover</item>


### PR DESCRIPTION
Based on your last updates, it seems like google play is completely out of the question now.
Fdroid doesn't have rating or anything it seems, so can't replace this with that.