### PR TITLE
Text only mode

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
@@ -100,6 +100,7 @@ public class ChanSettings {
     public static final OptionsSetting<MediaAutoLoadMode> imageAutoLoadNetwork;
     public static final OptionsSetting<MediaAutoLoadMode> videoAutoLoadNetwork;
     public static final BooleanSetting videoOpenExternal;
+    public static final BooleanSetting textOnly;
     public static final BooleanSetting videoErrorIgnore;
     public static final OptionsSetting<PostViewMode> boardViewMode;
     public static final IntegerSetting boardGridSpanCount;
@@ -191,6 +192,7 @@ public class ChanSettings {
         imageAutoLoadNetwork = new OptionsSetting<>(p, "preference_image_auto_load_network", MediaAutoLoadMode.values(), MediaAutoLoadMode.WIFI);
         videoAutoLoadNetwork = new OptionsSetting<>(p, "preference_video_auto_load_network", MediaAutoLoadMode.values(), MediaAutoLoadMode.WIFI);
         videoOpenExternal = new BooleanSetting(p, "preference_video_external", false);
+        textOnly = new BooleanSetting(p, "preference_text_only", false);
         videoErrorIgnore = new BooleanSetting(p, "preference_video_error_ignore", false);
         boardViewMode = new OptionsSetting<>(p, "preference_board_view_mode", PostViewMode.values(), PostViewMode.LIST);
         boardGridSpanCount = new IntegerSetting(p, "preference_board_grid_span_count", 0);

--- a/Clover/app/src/main/java/org/floens/chan/ui/cell/CardPostCell.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/cell/CardPostCell.java
@@ -184,7 +184,7 @@ public class CardPostCell extends CardView implements PostCellInterface, View.On
     private void bindPost(Theme theme, Post post) {
         bound = true;
 
-        if (post.hasImage) {
+        if (post.hasImage && !ChanSettings.textOnly.get()) {
             thumbnailView.setVisibility(View.VISIBLE);
             thumbnailView.setPostImage(post.image, thumbnailView.getWidth(), thumbnailView.getHeight());
         } else {

--- a/Clover/app/src/main/java/org/floens/chan/ui/cell/PostCell.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/cell/PostCell.java
@@ -323,7 +323,7 @@ public class PostCell extends LinearLayout implements PostCellInterface {
             filterMatchColor.setVisibility(View.GONE);
         }
 
-        if (post.hasImage) {
+        if (post.hasImage && !ChanSettings.textOnly.get()) {
             thumbnailView.setVisibility(View.VISIBLE);
             thumbnailView.setPostImage(post.image, thumbnailView.getLayoutParams().width, thumbnailView.getLayoutParams().height);
         } else {

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/MainSettingsController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/MainSettingsController.java
@@ -72,6 +72,7 @@ public class MainSettingsController extends SettingsController implements Toolba
     private SettingView fontView;
     private SettingView layoutModeView;
     private SettingView fontCondensed;
+    private SettingView textOnly;
     private SettingView gridColumnsView;
     private ToolbarMenuItem overflow;
 
@@ -172,6 +173,8 @@ public class MainSettingsController extends SettingsController implements Toolba
             EventBus.getDefault().post(new RefreshUIMessage("font"));
         } else if (item == gridColumnsView) {
             EventBus.getDefault().post(new RefreshUIMessage("gridcolumns"));
+        } else if (item == textOnly) {
+            EventBus.getDefault().post(new RefreshUIMessage("textonly"));
         }
     }
 
@@ -303,6 +306,8 @@ public class MainSettingsController extends SettingsController implements Toolba
         updateVideoLoadModes();
 
         browsing.add(new BooleanSettingView(this, ChanSettings.videoOpenExternal, R.string.setting_video_open_external, R.string.setting_video_open_external_description));
+        textOnly = new BooleanSettingView(this, ChanSettings.textOnly, R.string.setting_text_only, R.string.setting_text_only_description);
+        browsing.add(textOnly);
         browsing.add(new LinkSettingView(this, R.string.setting_clear_thread_hides, 0, new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -390,6 +390,8 @@ Re-enable this permission in the app settings if you permanently disabled it."</
     <string name="setting_video_auto_load_description">Depends on auto load images</string>
     <string name="setting_video_open_external">Open videos external</string>
     <string name="setting_video_open_external_description">Open videos in an external media player</string>
+    <string name="setting_text_only">Text only mode</string>
+    <string name="setting_text_only_description">Hide images when in board and thread view</string>
     <string name="setting_clear_thread_hides">Clear all thread hides</string>
     <string name="setting_cleared_thread_hides">Cleared all thread hides</string>
 


### PR DESCRIPTION
Added to 'Browsing' group in settings to make Clover text only/hide all images. This hides images in Board view, and inside threads. Images are still parsed and can be seen by opening gallery.

Wasn't too sure about the wording. I think I like 'Text only' better than 'Hide images'. But it could go either way.

This idea came up in one of the threads (with quite a few positive replies), and I thought it was a good idea too (for browsing in public reasons)