### PR TITLE
Set versionName in app.gradle from git tags instead of manual

### DIFF
--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 def getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'git', 'describe', '--tags', '--always'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -1,5 +1,17 @@
 apply plugin: 'com.android.application'
 
+/**
+ * Gets the version name from the latest Git tag
+ */
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
     compileSdkVersion 24
     // update the travis config when changing this
@@ -10,7 +22,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 24
 
-        versionName "v2.1.3"
+        versionName getVersionName()
         versionCode 55
     }
 


### PR DESCRIPTION
So this is kinda cool, this will set the versionName in app.gradle based on the output of `git describe --tags`. 

Example: building Clover after this commit sets the version string in the About section in options `v2.1.3-84-gdd647111 Debug`. `2.1.3` is the latest tag, `84` is the number of commits since that tag commit, `dd647111` is the latest commit hash, [the commit hash is prepended by `g`](http://git.661346.n2.nabble.com/meaning-of-g-in-git-describe-output-tp4753369p4754053.html).

If you were to checkout master/15fc60f/`tags/v2.1.3`, `git describe --tags` outputs `v2.1.3` cleanly.

This change would be invisible to normal users, since they are using the tagged commit, but helpful for devs/people who run latest and help identify which commit they are running.

[Explanation source](http://ryanharter.com/blog/2013/07/30/automatic-versioning-with-git-and-gradle/)

Question: should we remove the 'Debug' text?

idea from @emiliskvg
