### PR TITLE
Fixed bug #239 (probably)

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/saver/FileWatcher.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/saver/FileWatcher.java
@@ -19,15 +19,19 @@ package org.floens.chan.core.saver;
 
 import android.os.FileObserver;
 import android.util.Log;
+import android.widget.Toast;
 
 import org.floens.chan.core.model.FileItem;
 import org.floens.chan.core.model.FileItems;
+import org.floens.chan.R;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+
+import static org.floens.chan.utils.AndroidUtils.getAppContext;
 
 public class FileWatcher {
     private static final String TAG = "FileWatcher";
@@ -70,7 +74,13 @@ public class FileWatcher {
 
     public void navigateTo(File to) {
         if (!StorageHelper.canNavigate(to)) {
-            throw new IllegalArgumentException("Cannot navigate to " + to.getAbsolutePath());
+            if (to.getParentFile() != null) {
+                Toast.makeText(getAppContext(), String.format(getAppContext().getResources().getString(R.string.folder_not_found), to.getAbsolutePath(), to.getParentFile().getAbsolutePath()), Toast.LENGTH_LONG).show();
+                navigateTo(to.getParentFile());
+                return;
+            }
+            else
+                throw new IllegalArgumentException("Cannot navigate to " + to.getAbsolutePath());
         }
 
         if (fileObserver != null) {

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -355,6 +355,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <string name="filters_screen">Filters</string>
 
     <string name="save_location_screen">Save location</string>
+    <string name="folder_not_found">The folder \"%1$s\" has not been found; showing \"%2$s\" instead</string>
     <string name="write_permission_required_title">Storage permission required</string>
     <string name="write_permission_required">
 "Permission to access storage is required for browsing files.


### PR DESCRIPTION
Fixed a bug that made the app crash when the user tried to change the destination folder, and the previous folder didn't exist, which caused an exception that went uncaught. What I made was configuring the FileWatcher utility so that if the folder to open doesn't exist, it shows a Toast message and tries to open the parent folder (recursively, until one is found; if none are found, the same exception is thrown); this is arguably not the best solution, and has a possible problem: every Toast message warns about one folder not existing, so if there are many of those folders, the messages may get a bit confusing. However, it works, and does a better job at warning the user the folder doesn't exist than simply crashing does.
As this is my first pull request, and my first attempt at programming anything in Android, I wait your review, Floens; hopefully, I haven't messed up anything.