### PR TITLE
Version name

### DIFF
--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.application'
 def getVersionName = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'git', 'describe', '--tags', '--always'
         standardOutput = stdout
     }
     return stdout.toString().trim()

--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -1,5 +1,17 @@
 apply plugin: 'com.android.application'
 
+/**
+ * Gets the version name from the latest Git tag
+ */
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
     compileSdkVersion 24
     // update the travis config when changing this
@@ -10,7 +22,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 24
 
-        versionName "v2.2.0"
+        versionName getVersionName()
         versionCode 56
     }
 

--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.android.application'
 /**
  * Gets the version name from the latest Git tag
  */
-def getVersionName = { ->
+def getCommitHash = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags', '--always'
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
         standardOutput = stdout
     }
-    return stdout.toString().trim()
+    return "-" + stdout.toString().trim()
 }
 
 android {
@@ -22,7 +22,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 24
 
-        versionName getVersionName()
+        versionName "v2.2.0"
         versionCode 56
     }
 
@@ -76,7 +76,7 @@ android {
         }
 
         debug {
-            versionNameSuffix " Debug"
+            versionNameSuffix getCommitHash()
 //            minifyEnabled true
 //            proguardFiles 'proguard.cfg'
         }


### PR DESCRIPTION
Original PR #226 

I noticed when retesting this post-v2.2.2 release that the command, `git describe --tags --always`, gives the incorrect version number (v2.1.3). That is because it seems v2.2.2 was not tagged to a commit.

Output of of all the tags:
```
clover · dev ⟩ git tag
v1.0
v1.0.1
v1.0.2
v1.1
v1.1.1
v1.1.2
v1.1.3
v1.2.0
v1.2.1
v1.2.10
v1.2.11
v1.2.2
v1.2.3
v1.2.4
v1.2.5
v1.2.6
v1.2.7
v1.2.8
v1.2.9
v2.1.2
v2.1.3
```