### PR TITLE
Refactor detectLinks

### DIFF
--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -130,4 +130,5 @@ dependencies {
     compile 'com.davemorrissey.labs:subsampling-scale-image-view:3.5.0'
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'de.greenrobot:eventbus:2.4.0'
+    compile 'org.nibor.autolink:autolink:0.6.0'
 }

--- a/Clover/app/src/main/assets/html/licenses.html
+++ b/Clover/app/src/main/assets/html/licenses.html
@@ -194,5 +194,33 @@ The GIFLIB distribution is Copyright (c) 1997  Eric S. Raymond
         </code>
     </pre>
     <br>
+    <h3>autolink-java</h3>
+    <a href="https://github.com/robinst/autolink-java">https://github.com/robinst/autolink-java</a>
+    <pre>
+        <code>
+The MIT License (MIT)
+
+Copyright (c) 2015 Robin Stocker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+        </code>
+    </pre>
+    <br>
 </body>
 </html>


### PR DESCRIPTION
This replaces the link detection with [autolink-java](https://github.com/robinst/autolink-java#url-extraction) to detect the links in post text.

Done to fix #278 primarily, but will cover a lot more cases now too

Not sure how you feel about adding dependencies to Clover (autolink-java has no dependencies itself)