### PR TITLE
Add Insomnia theme

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/theme/ThemeHelper.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/theme/ThemeHelper.java
@@ -56,6 +56,7 @@ public class ThemeHelper {
         themes.add(new Theme("Yotsuba", "yotsuba", R.style.Chan_Theme_Yotsuba, PrimaryColor.RED));
         themes.add(new Theme("Yotsuba B", "yotsuba_b", R.style.Chan_Theme_YotsubaB, PrimaryColor.RED));
         themes.add(new Theme("Photon", "photon", R.style.Chan_Theme_Photon, PrimaryColor.ORANGE));
+        themes.add(new DarkTheme("Insomnia", "insomnia", R.style.Chan_Theme_Insomnia, PrimaryColor.DARK));
 
         ChanSettings.ThemeColor settingTheme = ChanSettings.getThemeAndColor();
         for (Theme theme : themes) {

--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -161,6 +161,44 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="post_inline_quote_color">#ffb5bd68</item>
 
     </style>
+    
+    <style name="Chan.Theme.Insomnia" parent="Chan.Theme.Dark">
+        <item name="colorAccent">#ff5f89ac</item>
+
+        <item name="backcolor">#ff222222</item>
+        <item name="backcolor_secondary">#ff242424</item>
+
+        <item name="android:textColor">#ff9e9e9e</item>
+        <item name="text_color_primary">#ff9e9e9e</item>
+        <item name="text_color_secondary">#ff9e9e9e</item>
+        <item name="text_color_hint">#ff9e9e9e</item>
+        <item name="text_color_reveal_spoiler">#ff9e9e9e</item>
+
+        <item name="post_name_color">#ff566e78</item>
+        <item name="post_subject_color">#ff567861</item>
+        <item name="post_details_color">#ff333333</item>
+        <item name="post_quote_color">#ff7e949e</item>
+        <item name="post_highlight_quote_color">#ff81a2be</item>
+        <item name="post_inline_quote_color">#ffa4a987</item>
+        <item name="post_link_color">#ff81a2be</item>
+        <item name="post_spoiler_color">#ff242424</item>
+        <item name="post_capcode_color">#ff9e9e9e</item>
+        <item name="post_last_seen_color">#ff9e9e9e</item>
+
+        <item name="post_id_background_light">#00000000</item>
+        <item name="post_id_background_dark">#00000000</item>
+        <item name="post_saved_reply_color">#ff111111</item>
+        <item name="post_highlighted_color">#ff111111</item>
+        <item name="post_selected_color">#ff111111</item>
+
+        <item name="divider_color">#ff222222</item>
+        <item name="divider_split_color">#ff222222</item>
+
+        <item name="dropdown_light_color">#ff222222</item>
+        <item name="dropdown_light_pressed_color">#ff333333</item>
+        <item name="dropdown_dark_color">#ff222222</item>
+        <item name="dropdown_dark_pressed_color">#ff333333</item>
+    </style>
 
     <!-- For FloatingMenu -->
     <style name="ToolbarDropDownListViewStyle" parent="Widget.AppCompat.ListView.DropDown">

--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -176,7 +176,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <item name="post_name_color">#ff566e78</item>
         <item name="post_subject_color">#ff567861</item>
-        <item name="post_details_color">#ff333333</item>
+        <item name="post_details_color">#ff444444</item>
         <item name="post_quote_color">#ff7e949e</item>
         <item name="post_highlight_quote_color">#ff81a2be</item>
         <item name="post_inline_quote_color">#ffa4a987</item>
@@ -187,17 +187,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <item name="post_id_background_light">#00000000</item>
         <item name="post_id_background_dark">#00000000</item>
-        <item name="post_saved_reply_color">#ff111111</item>
-        <item name="post_highlighted_color">#ff111111</item>
-        <item name="post_selected_color">#ff111111</item>
+        <item name="post_saved_reply_color">#ff1a1a1a</item>
+        <item name="post_highlighted_color">#ff1a1a1a</item>
+        <item name="post_selected_color">#ff1a1a1a</item>
 
         <item name="divider_color">#ff222222</item>
         <item name="divider_split_color">#ff222222</item>
 
-        <item name="dropdown_light_color">#ff222222</item>
-        <item name="dropdown_light_pressed_color">#ff333333</item>
-        <item name="dropdown_dark_color">#ff222222</item>
-        <item name="dropdown_dark_pressed_color">#ff333333</item>
+        <item name="dropdown_light_color">#ffffffff</item>
+        <item name="dropdown_light_pressed_color">#ffffffff</item>
+        <item name="dropdown_dark_color">#ffffffff</item>
+        <item name="dropdown_dark_pressed_color">#ffffffff</item>
     </style>
 
     <!-- For FloatingMenu -->


### PR DESCRIPTION
I'm actually kind of surprised there wasn't a single pull request for a theme yet.

Preview:

|![bjndgwg](https://cloud.githubusercontent.com/assets/8181990/24954211/b4948a3c-1f7e-11e7-8bf7-2cc7f9a056e8.png)|![9arjz0v](https://cloud.githubusercontent.com/assets/8181990/24954214/b68125bc-1f7e-11e7-961a-cc7968ee0f24.png)|
|:-:|:-:|

I got the color palette from [here](https://userstyles.org/styles/58791/4chan-insomnia) and really liked it, so I ported it.

As the page above states, the CSS code is copyrighted but I'll just rely on these [two](http://graphicdesign.stackexchange.com/questions/43290/copyright-of-a-set-of-colors) [pages](https://www.quora.com/Can-color-palettes-be-copyrighted) and say that the color palette isn't.

Of course I could be wrong, so if I am – sorry.