### PR TITLE
Use FileProvider to open videos in external apps

### DIFF
--- a/Clover/app/src/main/AndroidManifest.xml
+++ b/Clover/app/src/main/AndroidManifest.xml
@@ -94,6 +94,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         </receiver>
 
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="org.floens.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+
+        </provider>
+
     </application>
 
 </manifest>

--- a/Clover/app/src/main/java/org/floens/chan/ui/view/MultiImageView.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/view/MultiImageView.java
@@ -21,7 +21,7 @@ import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
 import android.media.MediaPlayer;
-import android.net.Uri;
+import android.support.v4.content.FileProvider;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
@@ -352,7 +352,8 @@ public class MultiImageView extends FrameLayout implements View.OnClickListener 
     private void setVideoFile(final File file) {
         if (ChanSettings.videoOpenExternal.get()) {
             Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.setDataAndType(Uri.fromFile(file), "video/*");
+            intent.setDataAndType(FileProvider.getUriForFile(getContext(), "org.floens.fileprovider", file), "video/*");
+            intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
             AndroidUtils.openIntent(intent);
             onModeLoaded(Mode.MOVIE, videoView);

--- a/Clover/app/src/main/res/xml/file_paths.xml
+++ b/Clover/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="fc" path="filecache/" />
+    <external-cache-path name="exfc" path="filecache/" />
+</paths>


### PR DESCRIPTION
Fixes #310 

If you don't mind.
Feel free to change authority (in manifest and MultiImageView) and names in file_paths. Docs [recommend](https://developer.android.com/reference/android/support/v4/content/FileProvider.html#ProviderDefinition) using my.domain+".fileprovider" (i.e. org.floens.fileprovider) as authority though.

