### PR TITLE
Added Gruvbox Light/Dark Themes

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/theme/ThemeHelper.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/theme/ThemeHelper.java
@@ -57,6 +57,8 @@ public class ThemeHelper {
         themes.add(new Theme("Yotsuba B", "yotsuba_b", R.style.Chan_Theme_YotsubaB, PrimaryColor.RED));
         themes.add(new Theme("Photon", "photon", R.style.Chan_Theme_Photon, PrimaryColor.ORANGE));
         themes.add(new DarkTheme("Insomnia", "insomnia", R.style.Chan_Theme_Insomnia, PrimaryColor.DARK));
+        themes.add(new Theme("Gruvbox Light", "gruvbox_light", R.style.Chan_Theme_GruvboxLight, PrimaryColor.BLACK));
+        themes.add(new DarkTheme("Gruvbox Dark", "gruvbox_dark", R.style.Chan_Theme_GruvboxDark, PrimaryColor.BLACK));
 
         ChanSettings.ThemeColor settingTheme = ChanSettings.getThemeAndColor();
         for (Theme theme : themes) {

--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -213,12 +213,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="text_color_reveal_spoiler">#3c3836</item>
 
         <item name="post_name_color">#689d6a</item>
-        <item name="post_subject_color">#458588</item>
+        <item name="post_subject_color">#076678</item>
         <item name="post_details_color">#7c6f64</item>
         <item name="post_quote_color">#cc241d</item>
         <item name="post_highlight_quote_color">#9d0006</item>
         <item name="post_inline_quote_color">#98971a</item>
-        <item name="post_link_color">#458588</item>
+        <item name="post_link_color">#076678</item>
         <item name="post_spoiler_color">#3c3836</item>
         <item name="post_capcode_color">#cc241d</item>
         <item name="post_last_seen_color">#cc241d</item>
@@ -248,12 +248,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="text_color_reveal_spoiler">#ebdbb2</item>
 
         <item name="post_name_color">#427b58</item>
-        <item name="post_subject_color">#076678</item>
+        <item name="post_subject_color">#458588</item>
         <item name="post_details_color">#a89984</item>
         <item name="post_quote_color">#9d0006</item>
         <item name="post_highlight_quote_color">#cc241d</item>
         <item name="post_inline_quote_color">#79740e</item>
-        <item name="post_link_color">#076678</item>
+        <item name="post_link_color">#458588</item>
         <item name="post_spoiler_color">#ebdbb2</item>
         <item name="post_capcode_color">#9d0006</item>
         <item name="post_last_seen_color">#9d0006</item>

--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -200,6 +200,76 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <item name="dropdown_dark_pressed_color">#ffffffff</item>
     </style>
 
+    <style name="Chan.Theme.GruvboxLight" parent="Chan.Theme">
+        <item name="colorAccent">#3c3836</item>
+
+        <item name="backcolor">#fbf1c7</item>
+        <item name="backcolor_secondary">#ebdbb2</item>
+
+        <item name="android:textColor">#3c3836</item>
+        <item name="text_color_primary">#3c3836</item>
+        <item name="text_color_secondary">#504945</item>
+        <item name="text_color_hint">#665c54</item>
+        <item name="text_color_reveal_spoiler">#3c3836</item>
+
+        <item name="post_name_color">#689d6a</item>
+        <item name="post_subject_color">#458588</item>
+        <item name="post_details_color">#7c6f64</item>
+        <item name="post_quote_color">#cc241d</item>
+        <item name="post_highlight_quote_color">#9d0006</item>
+        <item name="post_inline_quote_color">#98971a</item>
+        <item name="post_link_color">#458588</item>
+        <item name="post_spoiler_color">#3c3836</item>
+        <item name="post_capcode_color">#cc241d</item>
+        <item name="post_last_seen_color">#cc241d</item>
+
+        <item name="post_id_background_light">#3c3836</item>
+        <item name="post_saved_reply_color">#ebdbb2</item>
+        <item name="post_highlighted_color">#ebdbb2</item>
+        <item name="post_selected_color">#ebdbb2</item>
+
+        <item name="divider_color">#ebdbb2</item>
+        <item name="divider_split_color">#ebdbb2</item>
+
+        <item name="dropdown_dark_color">#736f5b</item>
+        <item name="dropdown_dark_pressed_color">#736f5b</item>
+    </style>
+
+    <style name="Chan.Theme.GruvboxDark" parent="Chan.Theme.Dark">
+        <item name="colorAccent">#ebdbb2</item>
+
+        <item name="backcolor">#282828</item>
+        <item name="backcolor_secondary">#3c3836</item>
+
+        <item name="android:textColor">#ebdbb2</item>
+        <item name="text_color_primary">#ebdbb2</item>
+        <item name="text_color_secondary">#d5c4a1</item>
+        <item name="text_color_hint">#bdae93</item>
+        <item name="text_color_reveal_spoiler">#ebdbb2</item>
+
+        <item name="post_name_color">#427b58</item>
+        <item name="post_subject_color">#076678</item>
+        <item name="post_details_color">#a89984</item>
+        <item name="post_quote_color">#9d0006</item>
+        <item name="post_highlight_quote_color">#cc241d</item>
+        <item name="post_inline_quote_color">#79740e</item>
+        <item name="post_link_color">#076678</item>
+        <item name="post_spoiler_color">#ebdbb2</item>
+        <item name="post_capcode_color">#9d0006</item>
+        <item name="post_last_seen_color">#9d0006</item>
+
+        <item name="post_id_background_light">#ebdbb2</item>
+        <item name="post_saved_reply_color">#3c3836</item>
+        <item name="post_highlighted_color">#3c3836</item>
+        <item name="post_selected_color">#3c3836</item>
+
+        <item name="divider_color">#3c3836</item>
+        <item name="divider_split_color">#3c3836</item>
+
+        <item name="dropdown_dark_color">#ffffff</item>
+        <item name="dropdown_dark_pressed_color">#ffffff</item>
+    </style>
+
     <!-- For FloatingMenu -->
     <style name="ToolbarDropDownListViewStyle" parent="Widget.AppCompat.ListView.DropDown">
         <item name="android:background">#ffffffff</item>

--- a/Clover/app/src/main/res/values/styles.xml
+++ b/Clover/app/src/main/res/values/styles.xml
@@ -187,12 +187,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <item name="post_id_background_light">#00000000</item>
         <item name="post_id_background_dark">#00000000</item>
-        <item name="post_saved_reply_color">#ff1a1a1a</item>
-        <item name="post_highlighted_color">#ff1a1a1a</item>
-        <item name="post_selected_color">#ff1a1a1a</item>
+        <item name="post_saved_reply_color">#ff1d1d1d</item>
+        <item name="post_highlighted_color">#ff1d1d1d</item>
+        <item name="post_selected_color">#ff1d1d1d</item>
 
-        <item name="divider_color">#ff222222</item>
-        <item name="divider_split_color">#ff222222</item>
+        <item name="divider_color">#00222222</item>
+        <item name="divider_split_color">#00222222</item>
 
         <item name="dropdown_light_color">#ffffffff</item>
         <item name="dropdown_light_pressed_color">#ffffffff</item>


### PR DESCRIPTION
Found out about [Gruvbox](https://github.com/morhetz/gruvbox). Fell in love with it. Got bored. Made another theme.

It keeps the basic Clover color scheme and only changes the colors so they match with the Gruvbox ones.
Example: Clover green becomes Gruvbox green.

|   |Gruvbox Light|Gruvbox Dark|
|---|---|---|
|Clover (Port)|![screenshot_1499599137](https://user-images.githubusercontent.com/8181990/27993328-3ad5e9a0-64a9-11e7-938d-fde689329287.png)|![screenshot_1499599130](https://user-images.githubusercontent.com/8181990/27993329-3ce73f14-64a9-11e7-88d3-869e10f10086.png)|
|Vim (Original)|<img width="1430" alt="687474703a2f2f692e696d6775722e636f6d2f5837356e6945612e706e67" src="https://user-images.githubusercontent.com/8181990/27993280-8a4b2c36-64a7-11e7-80c5-89e478255a81.png">|<img width="1430" alt="687474703a2f2f692e696d6775722e636f6d2f476b496c38466e2e706e67" src="https://user-images.githubusercontent.com/8181990/27993279-8a2d7cc2-64a7-11e7-9be6-3de73bd65401.png">|
|Color Palette|![687474703a2f2f692e696d6775722e636f6d2f3439714b7959572e706e67](https://user-images.githubusercontent.com/8181990/27993278-83b52872-64a7-11e7-9716-a1df77780942.png)|![687474703a2f2f692e696d6775722e636f6d2f776136363678672e706e67](https://user-images.githubusercontent.com/8181990/27993277-83b1658e-64a7-11e7-83bd-0863336a834d.png)|

Edit: Sorry for including an [already merged commit](https://github.com/Floens/Clover/pull/329/commits/6b82650c69709f8e7a691037e5fed2a7a19a2260), I guess Git (or I) didn't sync stuff properly.