### PR TITLE
Only include text when selecting 'Quote Text'

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/presenter/ReplyPresenter.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/presenter/ReplyPresenter.java
@@ -280,8 +280,11 @@ public class ReplyPresenter implements ReplyManager.HttpCallback<ReplyHttpCall>,
 
         if (withText) {
             String[] lines = post.comment.toString().split("\n+");
+            final Pattern quotePattern = Pattern.compile("^>>\\d+(\\s\\(OP\\))?$"); // matches for >>123 or >>123 (OP)
             for (String line : lines) {
-                textToInsert += ">" + line + "\n";
+                if(!quotePattern.matcher(line).matches()) { // do not include post no from quoted post
+                    textToInsert += ">" + line + "\n";
+                }
             }
         }
 


### PR DESCRIPTION
Do not include `>>post no` or `>>post no (OP)` when quoting with text

Fixes #334