### PR TITLE
Simplify regex when quoting with text

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/presenter/ReplyPresenter.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/presenter/ReplyPresenter.java
@@ -280,7 +280,7 @@ public class ReplyPresenter implements ReplyManager.HttpCallback<ReplyHttpCall>,
 
         if (withText) {
             String[] lines = post.comment.toString().split("\n+");
-            final Pattern quotePattern = Pattern.compile("^>>\\d+(\\s\\(OP\\))?$"); // matches for >>123 or >>123 (OP)
+            final Pattern quotePattern = Pattern.compile("^>>(>/[a-z0-9]+/)?\\d+.*$"); // matches for >>123, >>123 (OP), >>123 (You), >>>/fit/123
             for (String line : lines) {
                 if(!quotePattern.matcher(line).matches()) { // do not include post no from quoted post
                     textToInsert += ">" + line + "\n";


### PR DESCRIPTION
Simplify regex for removing post no when quoting with text

Matches for everything that it should, but not as performant as it could be, but the `lines` being tested are not that long