### PR TITLE
[WIP] Add parsing to links to provide more context

### DIFF
--- a/Clover/app/build.gradle
+++ b/Clover/app/build.gradle
@@ -112,6 +112,10 @@ android {
     sourceSets {
         beta.java.srcDirs = ['src/release/java']
     }
+
+    packagingOptions {
+        pickFirst 'META-INF/LICENSE'
+    }
 }
 
 dependencies {
@@ -131,4 +135,5 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'org.nibor.autolink:autolink:0.6.0'
+    compile 'com.github.andyklimczak:No-Embed-JVM:c72f2490f6'
 }

--- a/Clover/build.gradle
+++ b/Clover/build.gradle
@@ -11,5 +11,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url 'https://jitpack.io' }
     }
 }


### PR DESCRIPTION
* If the [noEmbed](https://noembed.com/) service can recognize a link when parsing post text, call the noEmbed service and replace the URL text in the post with more helpful text that shows the provider (source) and the title of the link.
* If the noEmbed service doesn't recognize the link, just skip over it and show the link as we do today
* If the noEmbed cannot parse the URL (not a real URL), `noEmbedBuilder.getData()` will throw an exception that we catch, and then show the link as we do today
* URLs will be replaced with the following format: `[Provider] Title of thing` (ie: `[YouTube] Video Title Here`)

I found this no embed service that seemed super useful. Just give it a url and it will spit meta info back about whatever was linked. So I wrote a [small wrapper around it](https://github.com/andyklimczak/No-Embed-JVM), and gave it two methods, a method to check that the url can be used with the service (regex function), and a http call that calls the service and actually gets the info.

What we're doing here, is when iterating through the links in a post, is checking to see if noEmbed is compatible with the link (no network call, just a regex). If it is compatible, then we do the network call for the info, and then replace the URL output with some output that provides more context to the link (ie: youtube video title).

Noembed guarantees that `provider` and `title` will be supplied for every link they handle, so we can always use them to give more context to the links.

This is a WIP because I want to test more, and I want to work with the stuff I had to change with `SpannableStringBuilder` to change the text in the `SpannableString` (`SpannableString` text is immutable) (I'm hoping that you might have an idea that I'm just missing to make it really simple)

Screenshot that should make everything clear:
![screenshot_20170903-193055](https://user-images.githubusercontent.com/4869742/30011954-efca770e-9109-11e7-9448-67c82162b2af.jpg)
