### PR TITLE
Support for arisuchan.jp and sushigirl.us

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/site/SiteRegistry.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/site/SiteRegistry.java
@@ -23,6 +23,7 @@ import org.floens.chan.core.site.sites.chan4.Chan4;
 import org.floens.chan.core.site.sites.lainchan.Lainchan;
 import org.floens.chan.core.site.sites.chan8.Chan8;
 import org.floens.chan.core.site.sites.arisuchan.Arisuchan;
+import org.floens.chan.core.site.sites.sushichan.Sushichan;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,7 @@ public class SiteRegistry {
         URL_HANDLERS.add(Chan8.URL_HANDLER);
         URL_HANDLERS.add(Lainchan.URL_HANDLER);
         URL_HANDLERS.add(Arisuchan.URL_HANDLER);
+        URL_HANDLERS.add(Sushichan.URL_HANDLER);
     }
 
     static {

--- a/Clover/app/src/main/java/org/floens/chan/core/site/SiteRegistry.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/site/SiteRegistry.java
@@ -22,6 +22,7 @@ import android.util.SparseArray;
 import org.floens.chan.core.site.sites.chan4.Chan4;
 import org.floens.chan.core.site.sites.lainchan.Lainchan;
 import org.floens.chan.core.site.sites.chan8.Chan8;
+import org.floens.chan.core.site.sites.arisuchan.Arisuchan;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,7 @@ public class SiteRegistry {
         URL_HANDLERS.add(Chan4.URL_HANDLER);
         URL_HANDLERS.add(Chan8.URL_HANDLER);
         URL_HANDLERS.add(Lainchan.URL_HANDLER);
+        URL_HANDLERS.add(Arisuchan.URL_HANDLER);
     }
 
     static {

--- a/Clover/app/src/main/java/org/floens/chan/core/site/SiteRegistry.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/site/SiteRegistry.java
@@ -51,5 +51,7 @@ public class SiteRegistry {
 
         SITE_CLASSES.put(1, Chan8.class);
         SITE_CLASSES.put(2, Lainchan.class);
+        SITE_CLASSES.put(3, Arisuchan.class);
+        SITE_CLASSES.put(4, Sushichan.class);
     }
 }

--- a/Clover/app/src/main/java/org/floens/chan/core/site/sites/arisuchan/Arisuchan.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/site/sites/arisuchan/Arisuchan.java
@@ -1,0 +1,104 @@
+/*
+ * Clover - 4chan browser https://github.com/Floens/Clover/
+ * Copyright (C) 2014  Floens
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.floens.chan.core.site.sites.arisuchan;
+
+import android.support.annotation.Nullable;
+
+import org.floens.chan.core.model.Post;
+import org.floens.chan.core.model.orm.Board;
+import org.floens.chan.core.model.orm.Loadable;
+import org.floens.chan.core.site.Site;
+import org.floens.chan.core.site.SiteIcon;
+import org.floens.chan.core.site.common.CommonSite;
+import org.floens.chan.core.site.common.vichan.VichanActions;
+import org.floens.chan.core.site.common.vichan.VichanApi;
+import org.floens.chan.core.site.common.vichan.VichanCommentParser;
+import org.floens.chan.core.site.common.vichan.VichanEndpoints;
+
+import okhttp3.HttpUrl;
+
+public class Arisuchan extends CommonSite {
+    public static final CommonSiteUrlHandler URL_HANDLER = new CommonSiteUrlHandler() {
+        @Override
+        public Class<? extends Site> getSiteClass() {
+            return Arisuchan.class;
+        }
+
+        @Override
+        public HttpUrl getUrl() {
+            return HttpUrl.parse("https://arisuchan.jp/");
+        }
+
+        @Override
+        public String[] getNames() {
+            return new String[]{"arisuchan"};
+        }
+
+        @Override
+        public String desktopUrl(Loadable loadable, @Nullable Post post) {
+            if (loadable.isCatalogMode()) {
+                return getUrl().newBuilder().addPathSegment(loadable.boardCode).toString();
+            } else if (loadable.isThreadMode()) {
+                return getUrl().newBuilder()
+                        .addPathSegment(loadable.boardCode).addPathSegment("res")
+                        .addPathSegment(String.valueOf(loadable.no) + ".html")
+                        .toString();
+            } else {
+                return getUrl().toString();
+            }
+        }
+    };
+
+    @Override
+    public void setup() {
+        setName("Arisuchan");
+        setIcon(SiteIcon.fromFavicon(HttpUrl.parse("https://arisuchan.jp/favicon.ico")));
+
+        setBoards(
+                Board.fromSiteNameCode(this, "art and design", "art"),
+                Board.fromSiteNameCode(this, "culture and media", "cult"),
+                Board.fromSiteNameCode(this, "cyberpunk and cybersecurity", "cyb"),
+                Board.fromSiteNameCode(this, "personal experiences", "feels"),
+                Board.fromSiteNameCode(this, "psychology and psychonautics", "psy"),
+                Board.fromSiteNameCode(this, "arisuchan meta", "q"),
+                Board.fromSiteNameCode(this, "miscellaneous", "r"),
+                Board.fromSiteNameCode(this, "киберпанк-доска", "ru"),
+                Board.fromSiteNameCode(this, "science and technology", "tech"),
+                Board.fromSiteNameCode(this, "paranoia", "x"),
+                Board.fromSiteNameCode(this, "zaibatsu", "z"),
+                Board.fromSiteNameCode(this, "diy and projects", "Δ"),
+                Board.fromSiteNameCode(this, "programming", "λ")
+        );
+
+        setResolvable(URL_HANDLER);
+
+        setConfig(new CommonConfig() {
+            @Override
+            public boolean feature(Feature feature) {
+                return feature == Feature.POSTING;
+            }
+        });
+
+        setEndpoints(new VichanEndpoints(this,
+                "https://arisuchan.jp",
+                "https://arisuchan.jp"));
+        setActions(new VichanActions(this));
+        setApi(new VichanApi(this));
+        setParser(new VichanCommentParser());
+    }
+}

--- a/Clover/app/src/main/java/org/floens/chan/core/site/sites/sushichan/Sushichan.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/site/sites/sushichan/Sushichan.java
@@ -1,0 +1,102 @@
+/*
+ * Clover - 4chan browser https://github.com/Floens/Clover/
+ * Copyright (C) 2014  Floens
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.floens.chan.core.site.sites.sushichan;
+
+import android.support.annotation.Nullable;
+
+import org.floens.chan.core.model.Post;
+import org.floens.chan.core.model.orm.Board;
+import org.floens.chan.core.model.orm.Loadable;
+import org.floens.chan.core.site.Site;
+import org.floens.chan.core.site.SiteIcon;
+import org.floens.chan.core.site.common.CommonSite;
+import org.floens.chan.core.site.common.vichan.VichanActions;
+import org.floens.chan.core.site.common.vichan.VichanApi;
+import org.floens.chan.core.site.common.vichan.VichanCommentParser;
+import org.floens.chan.core.site.common.vichan.VichanEndpoints;
+
+import okhttp3.HttpUrl;
+
+public class Sushichan extends CommonSite {
+    public static final CommonSiteUrlHandler URL_HANDLER = new CommonSiteUrlHandler() {
+        @Override
+        public Class<? extends Site> getSiteClass() {
+            return Sushichan.class;
+        }
+
+        @Override
+        public HttpUrl getUrl() {
+            return HttpUrl.parse("https://sushigirl.us/");
+        }
+
+        @Override
+        public String[] getNames() {
+            return new String[]{"sushichan"};
+        }
+
+        @Override
+        public String desktopUrl(Loadable loadable, @Nullable Post post) {
+            if (loadable.isCatalogMode()) {
+                return getUrl().newBuilder().addPathSegment(loadable.boardCode).toString();
+            } else if (loadable.isThreadMode()) {
+                return getUrl().newBuilder()
+                        .addPathSegment(loadable.boardCode).addPathSegment("res")
+                        .addPathSegment(String.valueOf(loadable.no) + ".html")
+                        .toString();
+            } else {
+                return getUrl().toString();
+            }
+        }
+    };
+
+    @Override
+    public void setup() {
+        setName("Sushichan");
+        setIcon(SiteIcon.fromFavicon(HttpUrl.parse("https://sushigirl.us/favicon.ico")));
+
+        setBoards(
+                Board.fromSiteNameCode(this, "artsy", "wildcard"),
+                Board.fromSiteNameCode(this, "sushi social", "lounge"),
+                Board.fromSiteNameCode(this, "site meta-discussion", "yakuza"),
+                Board.fromSiteNameCode(this, "vidya gaems", "arcade"),
+                Board.fromSiteNameCode(this, "cute things", "kawaii"),
+                Board.fromSiteNameCode(this, "tasty morsels & delights", "kitchen"),
+                Board.fromSiteNameCode(this, "enjoyable sounds", "tunes"),
+                Board.fromSiteNameCode(this, "arts & literature", "culture"),
+                Board.fromSiteNameCode(this, "technology", "silicon"),
+                Board.fromSiteNameCode(this, "internet death cult", "hell"),
+                Board.fromSiteNameCode(this, "dat ecchi & hentai goodness", "lewd")
+        );
+
+        setResolvable(URL_HANDLER);
+
+        setConfig(new CommonConfig() {
+            @Override
+            public boolean feature(Feature feature) {
+                return feature == Feature.POSTING;
+            }
+        });
+
+        setEndpoints(new VichanEndpoints(this,
+                "https://sushigirl.us/",
+                "https://sushigirl.us/"));
+        setActions(new VichanActions(this));
+        setApi(new VichanApi(this));
+        setParser(new VichanCommentParser());
+    }
+}


### PR DESCRIPTION
Addressing #431 and #499.

I'm not sure how to handle overboards such as arisuchan's [all](https://arisuchan.jp/all/) and sushichan's [kaitensushi](https://sushigirl.us/kaitensushi/) so they are left out.

While generic vichan support is on the way I thought that this might help ease the wait.