### PR TITLE
fixed always-open-in-browser to work with image menu

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
@@ -185,7 +185,11 @@ public class ImageViewerController extends Controller implements ImageViewerPres
 
     private void openBrowserClicked(ToolbarMenuSubItem item) {
         PostImage postImage = presenter.getCurrentPostImage();
-        AndroidUtils.openLinkInBrowser((Activity) context, postImage.imageUrl.toString());
+        if (ChanSettings.openLinkBrowser.get()) {
+            AndroidUtils.openLink(postImage.imageUrl.toString());
+        } else {
+            AndroidUtils.openLinkInBrowser((Activity) context, postImage.imageUrl.toString());
+        }
     }
 
     private void shareClicked(ToolbarMenuSubItem item) {


### PR DESCRIPTION
The 'Open in a browser' overflow menu item in the image viewer will now respect the new option "Always open links in external browser"