### PR TITLE
#500, Fix spoilers and links clashing

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/model/PostLinkable.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/PostLinkable.java
@@ -87,6 +87,10 @@ public class PostLinkable extends ClickableSpan {
         }
     }
 
+    public boolean getSpoilerState() {
+        return spoilerVisible;
+    }
+
     public static class ThreadLink {
         public String board;
         public int threadId;


### PR DESCRIPTION
Resolves #500, links will now unspoiler first, then be clickable (but will immediately re-spoiler)
Other functionality doesn't seem affected