### PR TITLE
"Failed to load image" only on center image fix

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
@@ -80,7 +80,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
 
         // Do this before the view is measured, to avoid it to always loading the first two pages
         callback.setPagerItems(images, selectedPosition);
-        callback.setImageMode(images.get(selectedPosition), MultiImageView.Mode.LOWRES);
+        callback.setImageMode(images.get(selectedPosition), MultiImageView.Mode.LOWRES, true);
     }
 
     public void onViewMeasured() {
@@ -106,7 +106,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
         PostImage postImage = images.get(selectedPosition);
         if (postImage.type == PostImage.Type.MOVIE) {
             // VideoView doesn't work with invisible visibility
-            callback.setImageMode(postImage, MultiImageView.Mode.LOWRES);
+            callback.setImageMode(postImage, MultiImageView.Mode.LOWRES, true);
         }
 
         callback.setPagerVisiblity(false);
@@ -173,7 +173,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
                 }
                 // Transition ended or not, request loading the other side views to lowres
                 for (PostImage other : getOther(selectedPosition, false)) {
-                    callback.setImageMode(other, MultiImageView.Mode.LOWRES);
+                    callback.setImageMode(other, MultiImageView.Mode.LOWRES, false);
                 }
                 onLowResInCenter();
             } else {
@@ -198,7 +198,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
         callback.scrollToImage(postImage);
 
         for (PostImage other : getOther(position, false)) {
-            callback.setImageMode(other, MultiImageView.Mode.LOWRES);
+            callback.setImageMode(other, MultiImageView.Mode.LOWRES, false);
         }
 
         // Already in LOWRES mode
@@ -218,11 +218,11 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
 
         if (imageAutoLoad(postImage) && !postImage.spoiler) {
             if (postImage.type == PostImage.Type.STATIC) {
-                callback.setImageMode(postImage, MultiImageView.Mode.BIGIMAGE);
+                callback.setImageMode(postImage, MultiImageView.Mode.BIGIMAGE, true);
             } else if (postImage.type == PostImage.Type.GIF) {
-                callback.setImageMode(postImage, MultiImageView.Mode.GIF);
+                callback.setImageMode(postImage, MultiImageView.Mode.GIF, true);
             } else if (postImage.type == PostImage.Type.MOVIE && videoAutoLoad(postImage)) {
-                callback.setImageMode(postImage, MultiImageView.Mode.MOVIE);
+                callback.setImageMode(postImage, MultiImageView.Mode.MOVIE, true);
             }
         }
 
@@ -282,18 +282,18 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
             PostImage postImage = images.get(selectedPosition);
             if (imageAutoLoad(postImage) && !postImage.spoiler) {
                 if (postImage.type == PostImage.Type.MOVIE) {
-                    callback.setImageMode(postImage, MultiImageView.Mode.MOVIE);
+                    callback.setImageMode(postImage, MultiImageView.Mode.MOVIE, true);
                 } else {
                     onExit();
                 }
             } else {
                 MultiImageView.Mode currentMode = callback.getImageMode(postImage);
                 if (postImage.type == PostImage.Type.STATIC && currentMode != MultiImageView.Mode.BIGIMAGE) {
-                    callback.setImageMode(postImage, MultiImageView.Mode.BIGIMAGE);
+                    callback.setImageMode(postImage, MultiImageView.Mode.BIGIMAGE, true);
                 } else if (postImage.type == PostImage.Type.GIF && currentMode != MultiImageView.Mode.GIF) {
-                    callback.setImageMode(postImage, MultiImageView.Mode.GIF);
+                    callback.setImageMode(postImage, MultiImageView.Mode.GIF, true);
                 } else if (postImage.type == PostImage.Type.MOVIE && currentMode != MultiImageView.Mode.MOVIE) {
-                    callback.setImageMode(postImage, MultiImageView.Mode.MOVIE);
+                    callback.setImageMode(postImage, MultiImageView.Mode.MOVIE, true);
                 } else {
                     onExit();
                 }
@@ -378,12 +378,9 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
     }
 
     private List<PostImage> getOther(int position, boolean all) {
-        List<PostImage> other = new ArrayList<>(3);
+        List<PostImage> other = new ArrayList<>(2);
         if (position - 1 >= 0) {
             other.add(images.get(position - 1));
-        }
-        if (all) {
-            other.add(images.get(position));
         }
         if (position + 1 < images.size()) {
             other.add(images.get(position + 1));
@@ -402,7 +399,7 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
 
         void setPagerItems(List<PostImage> images, int initialIndex);
 
-        void setImageMode(PostImage postImage, MultiImageView.Mode mode);
+        void setImageMode(PostImage postImage, MultiImageView.Mode mode, boolean center);
 
         void setVolume(PostImage postImage, boolean muted);
 

--- a/Clover/app/src/main/java/org/floens/chan/ui/adapter/ImageViewerAdapter.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/adapter/ImageViewerAdapter.java
@@ -76,18 +76,18 @@ public class ImageViewerAdapter extends ViewPagerAdapter {
             if (view == null) {
                 Logger.w(TAG, "finishUpdate setMode view still not found");
             } else {
-                view.setMode(change.mode);
+                view.setMode(change.mode, change.center);
             }
         }
         pendingModeChanges.clear();
     }
 
-    public void setMode(final PostImage postImage, MultiImageView.Mode mode) {
+    public void setMode(final PostImage postImage, MultiImageView.Mode mode, boolean center) {
         MultiImageView view = find(postImage);
         if (view == null) {
-            pendingModeChanges.add(new ModeChange(mode, postImage));
+            pendingModeChanges.add(new ModeChange(mode, postImage, center));
         } else {
-            view.setMode(mode);
+            view.setMode(mode, center);
         }
     }
 
@@ -119,10 +119,12 @@ public class ImageViewerAdapter extends ViewPagerAdapter {
     private static class ModeChange {
         public MultiImageView.Mode mode;
         public PostImage postImage;
+        public boolean center;
 
-        private ModeChange(MultiImageView.Mode mode, PostImage postImage) {
+        private ModeChange(MultiImageView.Mode mode, PostImage postImage, boolean center) {
             this.mode = mode;
             this.postImage = postImage;
+            this.center = center;
         }
     }
 }

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerController.java
@@ -263,8 +263,8 @@ public class ImageViewerController extends Controller implements ImageViewerPres
         pager.setCurrentItem(initialIndex);
     }
 
-    public void setImageMode(PostImage postImage, MultiImageView.Mode mode) {
-        ((ImageViewerAdapter) pager.getAdapter()).setMode(postImage, mode);
+    public void setImageMode(PostImage postImage, MultiImageView.Mode mode, boolean center) {
+        ((ImageViewerAdapter) pager.getAdapter()).setMode(postImage, mode, center);
     }
 
     @Override

--- a/Clover/app/src/main/java/org/floens/chan/ui/view/MultiImageView.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/view/MultiImageView.java
@@ -134,7 +134,7 @@ public class MultiImageView extends FrameLayout implements View.OnClickListener 
         return postImage;
     }
 
-    public void setMode(final Mode newMode) {
+    public void setMode(final Mode newMode, boolean center) {
         if (this.mode != newMode) {
 //            Logger.test("Changing mode from " + this.mode + " to " + newMode + " for " + postImage.thumbnailUrl);
             this.mode = newMode;
@@ -144,7 +144,7 @@ public class MultiImageView extends FrameLayout implements View.OnClickListener 
                 public boolean onMeasured(View view) {
                     switch (newMode) {
                         case LOWRES:
-                            setThumbnail(postImage.getThumbnailUrl().toString());
+                            setThumbnail(postImage.getThumbnailUrl().toString(), center);
                             break;
                         case BIGIMAGE:
                             setBigImage(postImage.imageUrl.toString());
@@ -203,7 +203,7 @@ public class MultiImageView extends FrameLayout implements View.OnClickListener 
         cancelLoad();
     }
 
-    private void setThumbnail(String thumbnailUrl) {
+    private void setThumbnail(String thumbnailUrl, boolean center) {
         if (getWidth() == 0 || getHeight() == 0) {
             Logger.e(TAG, "getWidth() or getHeight() returned 0, not loading");
             return;
@@ -218,7 +218,9 @@ public class MultiImageView extends FrameLayout implements View.OnClickListener 
             @Override
             public void onErrorResponse(VolleyError error) {
                 thumbnailRequest = null;
-                onError();
+                if(center) {
+                    onError();
+                }
             }
 
             @Override


### PR DESCRIPTION
Fixes "failed to load image" appearing when the the center image is the one that should be displaying that message, not the side other images. This is for the multiimage view swipe mode thing