### PR TITLE
Fix crossboard links

### DIFF
--- a/Clover/app/src/main/AndroidManifest.xml
+++ b/Clover/app/src/main/AndroidManifest.xml
@@ -77,6 +77,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <data android:host="4chan.org" />
                 <data android:host="www.4chan.org" />
                 <data android:host="boards.4chan.org" />
+                <data android:host="www.4channel.org" />
+                <data android:host="boards.4channel.org" />
                 <data android:host="8ch.net" />
             </intent-filter>
 

--- a/Clover/app/src/main/java/org/floens/chan/core/model/PostLinkable.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/model/PostLinkable.java
@@ -31,6 +31,7 @@ import org.floens.chan.ui.theme.Theme;
  * PostCell has a {@link PostCell.PostViewMovementMethod}, that searches spans at the location the TextView was tapped,
  * and handled if it was a PostLinkable.
  */
+@SuppressWarnings("JavadocReference")
 public class PostLinkable extends ClickableSpan {
     public enum Type {
         QUOTE, LINK, SPOILER, THREAD

--- a/Clover/app/src/main/java/org/floens/chan/core/site/sites/chan4/Chan4.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/site/sites/chan4/Chan4.java
@@ -40,6 +40,7 @@ import org.floens.chan.core.site.SiteRequestModifier;
 import org.floens.chan.core.site.SiteSetting;
 import org.floens.chan.core.site.SiteUrlHandler;
 import org.floens.chan.core.site.common.CommonReplyHttpCall;
+import org.floens.chan.core.site.common.DefaultPostParser;
 import org.floens.chan.core.site.common.FutabaChanReader;
 import org.floens.chan.core.site.http.DeleteRequest;
 import org.floens.chan.core.site.http.HttpCall;
@@ -47,6 +48,7 @@ import org.floens.chan.core.site.http.LoginRequest;
 import org.floens.chan.core.site.http.LoginResponse;
 import org.floens.chan.core.site.http.Reply;
 import org.floens.chan.core.site.parser.ChanReader;
+import org.floens.chan.core.site.parser.CommentParser;
 import org.floens.chan.utils.AndroidUtils;
 import org.floens.chan.utils.Logger;
 
@@ -77,7 +79,9 @@ public class Chan4 extends SiteBase {
         public boolean respondsTo(HttpUrl url) {
             return url.host().equals("4chan.org") ||
                     url.host().equals("www.4chan.org") ||
-                    url.host().equals("boards.4chan.org");
+                    url.host().equals("boards.4chan.org") ||
+                    url.host().equals("www.4channel.org") ||
+                    url.host().equals("boards.4channel.org");
         }
 
         @Override
@@ -562,7 +566,15 @@ public class Chan4 extends SiteBase {
 
     @Override
     public ChanReader chanReader() {
-        return new FutabaChanReader();
+        CommentParser commentParser = new CommentParser();
+        commentParser.addDefaultRules();
+        commentParser.addInternalDomain("4chan.org");
+        commentParser.addInternalDomain("www.4chan.org");
+        commentParser.addInternalDomain("boards.4chan.org");
+        commentParser.addInternalDomain("4channel.org");
+        commentParser.addInternalDomain("www.4channel.org");
+        commentParser.addInternalDomain("boards.4channel.org");
+        return new FutabaChanReader(new DefaultPostParser(commentParser));
     }
 
     @Override


### PR DESCRIPTION
Fixes linking to threads that on another board.
The issue arose with the 4chan/4channel split. The comment parser now has a list of domains that are seen as "internal", and uses that to still see it as in internal link.

See also #623 #599 