### PR TITLE
Hide toolbar when opening an image and media loading option

### DIFF
--- a/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/presenter/ImageViewerPresenter.java
@@ -364,6 +364,8 @@ public class ImageViewerPresenter implements MultiImageView.Callback, ViewPager.
             return false;
         } else if (networkType == ChanSettings.MediaAutoLoadMode.WIFI) {
             return isConnected(ConnectivityManager.TYPE_WIFI);
+        } else if (networkType == ChanSettings.MediaAutoLoadMode.WIFI_ETHERNET) {
+            return isConnected(ConnectivityManager.TYPE_ETHERNET) || isConnected(ConnectivityManager.TYPE_WIFI);
         } else if (networkType == ChanSettings.MediaAutoLoadMode.ALL) {
             return true;
         }

--- a/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
+++ b/Clover/app/src/main/java/org/floens/chan/core/settings/ChanSettings.java
@@ -35,10 +35,12 @@ import de.greenrobot.event.EventBus;
 
 public class ChanSettings {
     public enum MediaAutoLoadMode implements OptionSettingItem {
-        // ALways auto load, either wifi or mobile
+        // Always auto load, either wifi or mobile
         ALL("all"),
         // Only auto load if on wifi
         WIFI("wifi"),
+        // Wifi or ethernet
+        WIFI_ETHERNET("wifi | ethernet"),
         // Never auto load
         NONE("none");
 
@@ -98,6 +100,7 @@ public class ChanSettings {
     public static final BooleanSetting openLinkConfirmation;
     public static final BooleanSetting openLinkBrowser;
     public static final BooleanSetting autoRefreshThread;
+    public static final BooleanSetting showToolbarImages;
     //    public static final BooleanSetting imageAutoLoad;
     public static final OptionsSetting<MediaAutoLoadMode> imageAutoLoadNetwork;
     public static final OptionsSetting<MediaAutoLoadMode> videoAutoLoadNetwork;
@@ -178,6 +181,7 @@ public class ChanSettings {
         openLinkConfirmation = new BooleanSetting(p, "preference_open_link_confirmation", false);
         openLinkBrowser = new BooleanSetting(p, "preference_open_link_browser", false);
         autoRefreshThread = new BooleanSetting(p, "preference_auto_refresh_thread", true);
+        showToolbarImages = new BooleanSetting(p, "preference_show_toolbar_images", true);
 //        imageAutoLoad = new BooleanSetting(p, "preference_image_auto_load", true);
         imageAutoLoadNetwork = new OptionsSetting<>(p, "preference_image_auto_load_network", MediaAutoLoadMode.class, MediaAutoLoadMode.WIFI);
         videoAutoLoadNetwork = new OptionsSetting<>(p, "preference_video_auto_load_network", MediaAutoLoadMode.class, MediaAutoLoadMode.WIFI);

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/BehaviourSettingsController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/BehaviourSettingsController.java
@@ -152,6 +152,7 @@ public class BehaviourSettingsController extends SettingsController {
             post.add(new BooleanSettingView(this,
                     ChanSettings.openLinkConfirmation,
                     R.string.setting_open_link_confirmation, 0));
+
             post.add(new BooleanSettingView(this,
                     ChanSettings.openLinkBrowser,
                     R.string.setting_open_link_browser, 0));

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerNavigationController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/ImageViewerNavigationController.java
@@ -23,6 +23,7 @@ import org.floens.chan.R;
 import org.floens.chan.controller.ui.NavigationControllerContainerLayout;
 import org.floens.chan.core.model.PostImage;
 import org.floens.chan.core.model.orm.Loadable;
+import org.floens.chan.core.settings.ChanSettings;
 
 import java.util.List;
 
@@ -43,6 +44,8 @@ public class ImageViewerNavigationController extends ToolbarNavigationController
         nav.setNavigationController(this);
         nav.setSwipeEnabled(false);
         toolbar = view.findViewById(R.id.toolbar);
+        if (ChanSettings.showToolbarImages.get())
+            toolbar.getLayoutParams().height = 0;
         toolbar.setCallback(this);
     }
 

--- a/Clover/app/src/main/java/org/floens/chan/ui/controller/MediaSettingsController.java
+++ b/Clover/app/src/main/java/org/floens/chan/ui/controller/MediaSettingsController.java
@@ -122,6 +122,11 @@ public class MediaSettingsController extends SettingsController {
                     R.string.settings_reveal_image_spoilers,
                     R.string.settings_reveal_image_spoilers_description));
 
+            media.add(new BooleanSettingView(this,
+                    ChanSettings.showToolbarImages,
+                    R.string.setting_show_toolbar_images,
+                    R.string.setting_show_toolbar_images));
+
             groups.add(media);
         }
 
@@ -151,6 +156,9 @@ public class MediaSettingsController extends SettingsController {
                     break;
                 case WIFI:
                     name = R.string.setting_image_auto_load_wifi;
+                    break;
+                case WIFI_ETHERNET:
+                    name = R.string.setting_image_auto_load_wifi_ethernet;
                     break;
                 case NONE:
                     name = R.string.setting_image_auto_load_none;

--- a/Clover/app/src/main/res/values/strings.xml
+++ b/Clover/app/src/main/res/values/strings.xml
@@ -487,6 +487,7 @@ Crash reports do not collect any personally identifiable information."
     <string name="setting_tap_no_rely">Tap the post number to reply</string>
     <string name="setting_open_link_confirmation">Ask before opening links</string>
     <string name="setting_open_link_browser">Always open links in external browser</string>
+    <string name="setting_show_toolbar_images">Hide toolbar when opening an image</string>
 
 
     <!-- Behavior proxy group -->
@@ -526,6 +527,7 @@ If disabled, save the image with the filename the uploader assigned."
 
     <string name="setting_image_auto_load_all">Always</string>
     <string name="setting_image_auto_load_wifi">Wi-Fi only</string>
+    <string name="setting_image_auto_load_wifi_ethernet">Wi-Fi or Ethernet</string>
     <string name="setting_image_auto_load_none">Never</string>
 
     <string name="setting_video_auto_load">Automatically load videos</string>


### PR DESCRIPTION
Added the option to hide the toolbar when seeing images.
Current:
![Current](https://user-images.githubusercontent.com/16111357/67918231-0ec98c80-fb61-11e9-8b43-109d5f026a3c.png)
Proposed:
![example](https://user-images.githubusercontent.com/16111357/67918232-0ec98c80-fb61-11e9-934d-8b777ac5533d.png)
Also added another option for media connections, wifi or ethernet.